### PR TITLE
[ISSUE-496] :sparkles: Generics Refactor & displayName → name Migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ import { ResourceManager } from "@arimadata/resource-manager";
 const headers = [
   {
     columnName: 'Model Name',
-    getValue: (item) => item.displayName || 'None',
+    getValue: (item) => item.name || 'None',
     isNameColumn: true,
   },
 
@@ -70,7 +70,7 @@ function App() {
   const [items, setItems] = useState([
     {
       pk: "1",
-      displayName: "Documents",
+      name: "Documents",
       itemType: "folder",
       iconName: "BsFolderFill",
       parentPk: null,
@@ -78,7 +78,7 @@ function App() {
     },
     {
       pk: "2",
-      displayName: "Main Report",
+      name: "Main Report",
       itemType: "resource",
       iconName: "BsFileEarmarkFill"
       scopePk: 'test@gmail.com'
@@ -89,7 +89,7 @@ function App() {
         createdAt: "2025-09-04T15:39:24.358281Z",
         updatedAt: "2025-09-04T15:38:24.358281Z",
         description: "Test Description",
-        displayName: "Main Report",
+        name: "Main Report",
         pk: "6250780034072576",
         userPk: "test@gmail.com",
         tabs: [],
@@ -135,9 +135,9 @@ const handleCreateFolder = (data, lock) => {
 - Each item in the `items` array follows this structure:
 
 ```typescript
-interface ResourceManagerItem {
+interface ResourceManagerItem<T extends object = object> {
   pk: string; // Primary key
-  displayName: string; // Display name
+  name: string; // Display name
   itemType: "folder" | "resource"; // Type
   iconName: string; // Icon name
   isFavorited?: boolean; // Favorite status
@@ -145,8 +145,8 @@ interface ResourceManagerItem {
   scopePk: string; // External resource reference
   createdAt: string; // ISO 8601 timestamp
   updatedAt: string; // ISO 8601 timestamp
-  resource: Record<string, any> | null; // External resource reference
-  resourcePk: string; // External resource reference
+  resource?: T; // External resource reference
+  resourcePk?: string; // External resource reference
   resourceType: "mmm" | "report" | "audience"; // Type of resource
   parentPk?: string; // Parent item key (null for root)
 
@@ -154,15 +154,16 @@ interface ResourceManagerItem {
   isDirectory: boolean; // Computed from itemType
   path: string[]; // Computed path array
   isEditing: boolean; // Edit state
+  isTemporary: boolean; // Temporary state
 }
 ```
 
 - Each header in the `headers` array follows this structure:
 
 ```typescript
-interface ResourceManagerHeader {
+interface ResourceManagerHeader<T extends object> {
   columnName: string; // Column name
-  getValue: (item: ResourceManagerItem) => any; // Getter function to extract the value for this column from a resource/folder item
+  getValue: (item: ResourceManagerItem<T>) => any; // Getter function to extract the value for this column from a resource/folder item
   sortAccessor?: (value: any) => any; // Accessor for sorting purposes
   isNameColumn?: boolean; // Mark this column as name column. Used for favorite button, icons and select checkbox placement
 }
@@ -266,27 +267,27 @@ const onCreateItem = (data, release) => {
 
 ## 🎨 Props
 
-| Prop                | Type                      | Description                                        |
-| ------------------- | ------------------------- | -------------------------------------------------- |
-| `items`             | `ResourceManagerItem[]`   | Array of items to display                          |
-| `headers`           | `ResourceManagerHeader[]` | Array of headers to use                            |
-| `isLoading`         | `boolean`                 | Loading state indicator                            |
-| `allowCreateFolder` | `boolean`                 | Enable folder creation (default: `true`)           |
-| `allowCreateItem`   | `boolean`                 | Enable custom item creation (default: `true`)      |
-| `allowDelete`       | `boolean`                 | Enable deletion (default: `true`)                  |
-| `allowRefresh`      | `boolean`                 | Enable refresh (default: `true`)                   |
-| `allowDuplicate`    | `boolean`                 | Enable duplicate (default: `false`)                |
-| `allowRename`       | `boolean`                 | Enable renaming (default: `true`)                  |
-| `allowCopy`         | `boolean`                 | Enable copying (default: `true`)                   |
-| `allowCut`          | `boolean`                 | Enable cutting (default: `true`)                   |
-| `allowPaste`        | `boolean`                 | Enable pasting (default: `true`)                   |
-| `allowFavorite`     | `boolean`                 | Enable favorites (default: `true`)                 |
-| `allowShareItem`    | `boolean`                 | Enable sharing (default: `true`)                   |
-| `initialPath`       | `string[]`                | Initial navigation path                            |
-| `height`            | `string \| number`        | Component height (default: `"100%"`)               |
-| `width`             | `string \| number`        | Component width (default: `"100%"`)                |
-| `primaryColor`      | `string`                  | Primary theme color (default: `"#6155b4"`)         |
-| `fontFamily`        | `string`                  | Font family (default: `"Nunito Sans, sans-serif"`) |
+| Prop                | Type                         | Description                                        |
+| ------------------- | ---------------------------- | -------------------------------------------------- |
+| `items`             | `ResourceManagerItem<T>[]`   | Array of items to display                          |
+| `headers`           | `ResourceManagerHeader<T>[]` | Array of headers to use                            |
+| `isLoading`         | `boolean`                    | Loading state indicator                            |
+| `allowCreateFolder` | `boolean`                    | Enable folder creation (default: `true`)           |
+| `allowCreateItem`   | `boolean`                    | Enable custom item creation (default: `true`)      |
+| `allowDelete`       | `boolean`                    | Enable deletion (default: `true`)                  |
+| `allowRefresh`      | `boolean`                    | Enable refresh (default: `true`)                   |
+| `allowDuplicate`    | `boolean`                    | Enable duplicate (default: `false`)                |
+| `allowRename`       | `boolean`                    | Enable renaming (default: `true`)                  |
+| `allowCopy`         | `boolean`                    | Enable copying (default: `true`)                   |
+| `allowCut`          | `boolean`                    | Enable cutting (default: `true`)                   |
+| `allowPaste`        | `boolean`                    | Enable pasting (default: `true`)                   |
+| `allowFavorite`     | `boolean`                    | Enable favorites (default: `true`)                 |
+| `allowShareItem`    | `boolean`                    | Enable sharing (default: `true`)                   |
+| `initialPath`       | `string[]`                   | Initial navigation path                            |
+| `height`            | `string \| number`           | Component height (default: `"100%"`)               |
+| `width`             | `string \| number`           | Component width (default: `"100%"`)                |
+| `primaryColor`      | `string`                     | Primary theme color (default: `"#6155b4"`)         |
+| `fontFamily`        | `string`                     | Font family (default: `"Nunito Sans, sans-serif"`) |
 
 ## 🏗️ Architecture
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -32,7 +32,7 @@ import { ResourceManager } from "@arimadata/resource-manager";
 const headers = [
   {
     columnName: 'Model Name',
-    getValue: (item) => item.displayName || 'None',
+    getValue: (item) => item.name || 'None',
     isNameColumn: true,
   },
 
@@ -70,7 +70,7 @@ function App() {
   const [items, setItems] = useState([
     {
       pk: "1",
-      displayName: "Documents",
+      name: "Documents",
       itemType: "folder",
       iconName: "BsFolderFill",
       parentPk: null,
@@ -78,7 +78,7 @@ function App() {
     },
     {
       pk: "2",
-      displayName: "Main Report",
+      name: "Main Report",
       itemType: "resource",
       iconName: "BsFileEarmarkFill"
       scopePk: 'test@gmail.com'
@@ -89,7 +89,7 @@ function App() {
         createdAt: "2025-09-04T15:39:24.358281Z",
         updatedAt: "2025-09-04T15:38:24.358281Z",
         description: "Test Description",
-        displayName: "Main Report",
+        name: "Main Report",
         pk: "6250780034072576",
         userPk: "test@gmail.com",
         tabs: [],
@@ -135,9 +135,9 @@ const handleCreateFolder = (data, lock) => {
 - Each item in the `items` array follows this structure:
 
 ```typescript
-interface ResourceManagerItem {
+interface ResourceManagerItem<T extends object = object> {
   pk: string; // Primary key
-  displayName: string; // Display name
+  name: string; // Display name
   itemType: "folder" | "resource"; // Type
   iconName: string; // Icon name
   isFavorited?: boolean; // Favorite status
@@ -145,8 +145,8 @@ interface ResourceManagerItem {
   scopePk: string; // External resource reference
   createdAt: string; // ISO 8601 timestamp
   updatedAt: string; // ISO 8601 timestamp
-  resource: Record<string, any> | null; // External resource reference
-  resourcePk: string; // External resource reference
+  resource?: T; // External resource reference
+  resourcePk?: string; // External resource reference
   resourceType: "mmm" | "report" | "audience"; // Type of resource
   parentPk?: string; // Parent item key (null for root)
 
@@ -154,15 +154,16 @@ interface ResourceManagerItem {
   isDirectory: boolean; // Computed from itemType
   path: string[]; // Computed path array
   isEditing: boolean; // Edit state
+  isTemporary: boolean; // Temporary state
 }
 ```
 
 - Each header in the `headers` array follows this structure:
 
 ```typescript
-interface ResourceManagerHeader {
+interface ResourceManagerHeader<T extends object> {
   columnName: string; // Column name
-  getValue: (item: ResourceManagerItem) => any; // Getter function to extract the value for this column from a resource/folder item
+  getValue: (item: ResourceManagerItem<T>) => any; // Getter function to extract the value for this column from a resource/folder item
   sortAccessor?: (value: any) => any; // Accessor for sorting purposes
   isNameColumn?: boolean; // Mark this column as name column. Used for favorite button, icons and select checkbox placement
 }
@@ -266,27 +267,27 @@ const onCreateItem = (data, release) => {
 
 ## 🎨 Props
 
-| Prop                | Type                      | Description                                        |
-| ------------------- | ------------------------- | -------------------------------------------------- |
-| `items`             | `ResourceManagerItem[]`   | Array of items to display                          |
-| `headers`           | `ResourceManagerHeader[]` | Array of headers to use                            |
-| `isLoading`         | `boolean`                 | Loading state indicator                            |
-| `allowCreateFolder` | `boolean`                 | Enable folder creation (default: `true`)           |
-| `allowCreateItem`   | `boolean`                 | Enable custom item creation (default: `true`)      |
-| `allowDelete`       | `boolean`                 | Enable deletion (default: `true`)                  |
-| `allowDuplicate`    | `boolean`                 | Enable duplicate (default: `false`)                |
-| `allowRefresh`      | `boolean`                 | Enable refresh (default: `true`)                   |
-| `allowRename`       | `boolean`                 | Enable renaming (default: `true`)                  |
-| `allowCopy`         | `boolean`                 | Enable copying (default: `true`)                   |
-| `allowCut`          | `boolean`                 | Enable cutting (default: `true`)                   |
-| `allowPaste`        | `boolean`                 | Enable pasting (default: `true`)                   |
-| `allowFavorite`     | `boolean`                 | Enable favorites (default: `true`)                 |
-| `allowShareItem`    | `boolean`                 | Enable sharing (default: `true`)                   |
-| `initialPath`       | `string[]`                | Initial navigation path                            |
-| `height`            | `string \| number`        | Component height (default: `"100%"`)               |
-| `width`             | `string \| number`        | Component width (default: `"100%"`)                |
-| `primaryColor`      | `string`                  | Primary theme color (default: `"#6155b4"`)         |
-| `fontFamily`        | `string`                  | Font family (default: `"Nunito Sans, sans-serif"`) |
+| Prop                | Type                         | Description                                        |
+| ------------------- | ---------------------------- | -------------------------------------------------- |
+| `items`             | `ResourceManagerItem<T>[]`   | Array of items to display                          |
+| `headers`           | `ResourceManagerHeader<T>[]` | Array of headers to use                            |
+| `isLoading`         | `boolean`                    | Loading state indicator                            |
+| `allowCreateFolder` | `boolean`                    | Enable folder creation (default: `true`)           |
+| `allowCreateItem`   | `boolean`                    | Enable custom item creation (default: `true`)      |
+| `allowDelete`       | `boolean`                    | Enable deletion (default: `true`)                  |
+| `allowDuplicate`    | `boolean`                    | Enable duplicate (default: `false`)                |
+| `allowRefresh`      | `boolean`                    | Enable refresh (default: `true`)                   |
+| `allowRename`       | `boolean`                    | Enable renaming (default: `true`)                  |
+| `allowCopy`         | `boolean`                    | Enable copying (default: `true`)                   |
+| `allowCut`          | `boolean`                    | Enable cutting (default: `true`)                   |
+| `allowPaste`        | `boolean`                    | Enable pasting (default: `true`)                   |
+| `allowFavorite`     | `boolean`                    | Enable favorites (default: `true`)                 |
+| `allowShareItem`    | `boolean`                    | Enable sharing (default: `true`)                   |
+| `initialPath`       | `string[]`                   | Initial navigation path                            |
+| `height`            | `string \| number`           | Component height (default: `"100%"`)               |
+| `width`             | `string \| number`           | Component width (default: `"100%"`)                |
+| `primaryColor`      | `string`                     | Primary theme color (default: `"#6155b4"`)         |
+| `fontFamily`        | `string`                     | Font family (default: `"Nunito Sans, sans-serif"`) |
 
 ## 🎛️ Customization
 
@@ -298,7 +299,7 @@ Define custom column headers to display different data fields:
 const headers = [
   {
     columnName: "Model Name",
-    getValue: (item) => item.displayName || "None",
+    getValue: (item) => item.name || "None",
     isNameColumn: true, // This column will show icons, checkboxes, and favorite buttons
   },
   {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "@arimadata/resource-manager",
   "description": "A React resource manager with event-driven architecture and keyboard shortcuts. Designed to resemble Dropbox, it provides a complete interface for managing files and folders with built-in hooks for database persistence.",
   "private": false,
-  "version": "0.1.5",
+  "version": "0.1.6",
   "type": "module",
   "main": "dist/resource-manager.cjs.js",
   "module": "dist/resource-manager.es.js",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -21,7 +21,7 @@ const closedModal = {
 const headers = [
   {
     columnName: "Model Name",
-    getValue: (item) => item.displayName || "None",
+    getValue: (item) => item.name || "None",
     isNameColumn: true,
   },
 
@@ -57,7 +57,7 @@ const headers = [
 const initialItems = [
   {
     pk: "1",
-    displayName: "Documents",
+    name: "Documents",
     itemType: "folder",
     iconName: "BsFolderFill",
     parentPk: null,
@@ -65,7 +65,7 @@ const initialItems = [
   },
   {
     createdAt: "2025-09-09T09:35:17.634046Z",
-    displayName: "Test Report",
+    name: "Test Report",
     iconName: "BsFileEarmarkFill",
     isFavorited: false,
     itemType: "resource",
@@ -74,7 +74,7 @@ const initialItems = [
       createdAt: "2025-09-04T15:38:24.358281Z",
       updatedAt: "2025-09-04T15:38:24.358281Z",
       description: "Test Description",
-      displayName: "Test Report",
+      name: "Test Report",
       pk: "6250780034072576",
       userPk: "test@gmail.com",
       tabs: [],
@@ -88,7 +88,7 @@ const initialItems = [
   },
   {
     createdAt: "2025-09-09T09:35:17.634046Z",
-    displayName: "Test Report 1",
+    name: "Test Report 1",
     iconName: "BsFileEarmarkFill",
     isFavorited: false,
     itemType: "resource",
@@ -97,7 +97,7 @@ const initialItems = [
       createdAt: "2025-09-04T15:39:24.358281Z",
       updatedAt: "2025-09-04T15:38:24.358281Z",
       description: "Test Description",
-      displayName: "Test Report 2",
+      name: "Test Report 2",
       pk: "6250780034072576",
       userPk: "test@gmail.com",
       tabs: [],

--- a/frontend/src/ResourceManager/BreadCrumb/BreadCrumb.jsx
+++ b/frontend/src/ResourceManager/BreadCrumb/BreadCrumb.jsx
@@ -40,7 +40,7 @@ const BreadCrumb = ({ eventBroker }) => {
 
       if (item) {
         breadcrumbFolders.push({
-          name: item.displayName,
+          name: item.name,
           path: currentPath.slice(0, i + 1),
         });
       }

--- a/frontend/src/ResourceManager/Events/CreateFolder/CreateFolder.action.jsx
+++ b/frontend/src/ResourceManager/Events/CreateFolder/CreateFolder.action.jsx
@@ -8,7 +8,7 @@ import { dateStringValidator } from "../../../validators/propValidators";
 import PropTypes from "prop-types";
 
 const CreateFolderAction = ({ itemsViewRef, item, eventBroker }) => {
-  const [folderName, setFolderName] = useState(item.displayName);
+  const [folderName, setFolderName] = useState(item.name);
   const [folderNameError, setFolderNameError] = useState(false);
   const [folderErrorMessage, setFolderErrorMessage] = useState("");
   const [errorXPlacement, setErrorXPlacement] = useState("right");
@@ -62,7 +62,7 @@ const CreateFolderAction = ({ itemsViewRef, item, eventBroker }) => {
     );
 
     const alreadyExists = syncedCurrPathItems.find((i) => {
-      return i.displayName.toLowerCase() === newFolderName.toLowerCase();
+      return i.name.toLowerCase() === newFolderName.toLowerCase();
     });
 
     if (alreadyExists) {
@@ -82,7 +82,7 @@ const CreateFolderAction = ({ itemsViewRef, item, eventBroker }) => {
 
     eventBroker.publish("createFolderDone", {
       ...item,
-      displayName: newFolderName,
+      name: newFolderName,
       isEditing: false,
       isTemporary: false,
     });
@@ -149,7 +149,7 @@ CreateFolderAction.propTypes = {
   item: PropTypes.shape({
     // Original structure fields
     pk: PropTypes.string.isRequired,
-    displayName: PropTypes.string.isRequired,
+    name: PropTypes.string.isRequired,
     itemType: PropTypes.oneOf(["folder", "resource"]).isRequired,
     iconName: PropTypes.string,
     isFavorited: PropTypes.bool,

--- a/frontend/src/ResourceManager/Events/Delete/Delete.action.jsx
+++ b/frontend/src/ResourceManager/Events/Delete/Delete.action.jsx
@@ -8,7 +8,7 @@ const DeleteAction = ({ eventBroker }) => {
 
   const getDeleteMessage = () => {
     if (selectedItems.length === 1) {
-      return `Are you sure you want to delete "${selectedItems[0].displayName}"?`;
+      return `Are you sure you want to delete "${selectedItems[0].name}"?`;
     } else if (selectedItems.length > 1) {
       return `Are you sure you want to delete these ${selectedItems.length} items?`;
     }

--- a/frontend/src/ResourceManager/Events/EventSubscribers.jsx
+++ b/frontend/src/ResourceManager/Events/EventSubscribers.jsx
@@ -155,7 +155,7 @@ export const EventSubscribers = ({
     //   component: (
     //     <>{`Share [${selectedItems
     //       .filter((item) => !item.isDirectory)
-    //       .map((item) => item.displayName)
+    //       .map((item) => item.name)
     //       .join(", ")}]`}</>
     //   ),
     //   width: "35%",

--- a/frontend/src/ResourceManager/Events/Rename/Rename.action.jsx
+++ b/frontend/src/ResourceManager/Events/Rename/Rename.action.jsx
@@ -7,7 +7,7 @@ import PropTypes from "prop-types";
 import { dateStringValidator } from "../../../validators/propValidators";
 
 const RenameAction = ({ itemsViewRef, item, eventBroker }) => {
-  const [renameItem, setRenameItem] = useState(item?.displayName);
+  const [renameItem, setRenameItem] = useState(item?.name);
   // const [renameItemWarning, setRenameItemWarning] = useState(false);
   const [itemRenameError, setItemRenameError] = useState(false);
   const [renameErrorMessage, setRenameErrorMessage] = useState("");
@@ -52,11 +52,9 @@ const RenameAction = ({ itemsViewRef, item, eventBroker }) => {
   }, [itemRenameError]);
 
   function handleFileRenaming() {
-    if (renameItem === "" || renameItem === item.displayName) {
+    if (renameItem === "" || renameItem === item.name) {
       eventBroker.publish("cancel");
-    } else if (
-      currentPathItems.some((file) => file.displayName === renameItem)
-    ) {
+    } else if (currentPathItems.some((file) => file.name === renameItem)) {
       // new name already exists in current folder
       setItemRenameError(true);
       setRenameErrorMessage(
@@ -68,7 +66,7 @@ const RenameAction = ({ itemsViewRef, item, eventBroker }) => {
       setItemRenameError(false);
       eventBroker.publish("renameItemDone", {
         ...item,
-        displayName: renameItem,
+        name: renameItem,
         isEditing: false,
       });
     }
@@ -142,7 +140,7 @@ RenameAction.propTypes = {
   itemsViewRef: PropTypes.object.isRequired,
   item: PropTypes.shape({
     pk: PropTypes.string.isRequired,
-    displayName: PropTypes.string.isRequired,
+    name: PropTypes.string.isRequired,
     itemType: PropTypes.oneOf(["folder", "resource"]).isRequired,
     iconName: PropTypes.string,
     isFavorited: PropTypes.bool,

--- a/frontend/src/ResourceManager/ItemList/Item.jsx
+++ b/frontend/src/ResourceManager/ItemList/Item.jsx
@@ -42,8 +42,7 @@ const Item = ({
   const isItemMoving =
     clipBoard?.isMoving &&
     clipBoard.items.find(
-      (i) =>
-        i.displayName === item.displayName && arraysEqual(i.path, item.path)
+      (i) => i.name === item.name && arraysEqual(i.path, item.path)
     );
   const canSelectItems = eventBroker.canTransition("selectItems");
 
@@ -164,9 +163,7 @@ const Item = ({
     } else {
       setSelectedItems((prev) =>
         prev.filter(
-          (f) =>
-            f.displayName !== item.displayName &&
-            !arraysEqual(f.path, item.path)
+          (f) => f.name !== item.name && !arraysEqual(f.path, item.path)
         )
       );
     }
@@ -259,7 +256,7 @@ const Item = ({
             } ${dropZoneClass} ${
               itemSelected || !!item.isEditing ? "item-selected" : ""
             } ${isItemMoving ? "item-moving" : ""}`}
-            title={isNameColumn ? item.displayName : undefined}
+            title={isNameColumn ? item.name : undefined}
             onClick={handleItemSelection}
             onContextMenu={handleItemContextMenu}
             onMouseEnter={handleMouseOver}
@@ -293,8 +290,8 @@ const Item = ({
                 {/* Selection Checkbox Cell */}
                 {!item.isEditing && (
                   <Checkbox
-                    name={item.displayName}
-                    id={item.displayName}
+                    name={item.name}
+                    id={item.name}
                     checked={itemSelected}
                     className={`selection-checkbox ${checkboxClassName}`}
                     onChange={handleCheckboxChange}
@@ -381,7 +378,7 @@ const Item = ({
 
       {/* Drag Icon & Tooltip Setup */}
       {tooltipPosition && (
-        <Tooltip tooltipPosition={tooltipPosition} name={item.displayName} />
+        <Tooltip tooltipPosition={tooltipPosition} name={item.name} />
       )}
 
       <div ref={dragIconRef} className="drag-icon">
@@ -397,7 +394,7 @@ Item.propTypes = {
   index: PropTypes.number.isRequired,
   item: PropTypes.shape({
     pk: PropTypes.string.isRequired,
-    displayName: PropTypes.string.isRequired,
+    name: PropTypes.string.isRequired,
     itemType: PropTypes.oneOf(["folder", "resource"]).isRequired,
     iconName: PropTypes.string,
     isFavorited: PropTypes.bool,

--- a/frontend/src/ResourceManager/ResourceManager.jsx
+++ b/frontend/src/ResourceManager/ResourceManager.jsx
@@ -180,7 +180,7 @@ ResourceManager.propTypes = {
     PropTypes.shape({
       // Original structure fields
       pk: PropTypes.string.isRequired,
-      displayName: PropTypes.string.isRequired,
+      name: PropTypes.string.isRequired,
       itemType: PropTypes.oneOf(["folder", "resource"]).isRequired,
       iconName: PropTypes.string,
       isFavorited: PropTypes.bool,

--- a/frontend/src/api/createItemAPI.js
+++ b/frontend/src/api/createItemAPI.js
@@ -5,7 +5,7 @@ export const createItemAPI = async (item) => {
     const response = await api.post("/item", {
       parentPk: item.parentPk,
       itemType: item.itemType,
-      displayName: item.displayName,
+      name: item.name,
       resourceType: item.resourceType,
       resourcePk: item.resourcePk,
     });

--- a/frontend/src/api/itemTransferAPI.js
+++ b/frontend/src/api/itemTransferAPI.js
@@ -5,7 +5,7 @@ export const copyItemAPI = async (copiedItems, destinationPk) => {
     const promises = copiedItems.map((item) =>
       api.post(`/item/${item.pk}/copy`, {
         parentPk: destinationPk,
-        displayName: item.displayName, // In case of rename
+        name: item.name, // In case of rename
       })
     );
     const response = await Promise.all(promises);

--- a/frontend/src/api/renameAPI.js
+++ b/frontend/src/api/renameAPI.js
@@ -3,7 +3,7 @@ import { api } from "./api";
 export const renameAPI = async (item) => {
   try {
     const response = await api.patch(`/item/${item.pk}`, {
-      displayName: item.displayName,
+      name: item.name,
     });
     return response;
   } catch (error) {

--- a/frontend/src/contexts/ItemsContext.jsx
+++ b/frontend/src/contexts/ItemsContext.jsx
@@ -49,7 +49,7 @@ export const ItemsProvider = ({ children, itemsData }) => {
     const defaultValues = {
       pk: null,
       parentPk: null,
-      displayName: "",
+      name: "",
       isEditing: false,
       isFavorited: false,
       resource: null,
@@ -104,7 +104,7 @@ ItemsProvider.propTypes = {
   itemsData: PropTypes.arrayOf(
     PropTypes.shape({
       pk: PropTypes.string.isRequired,
-      displayName: PropTypes.string.isRequired,
+      name: PropTypes.string.isRequired,
       itemType: PropTypes.oneOf(["folder", "resource"]).isRequired,
       iconName: PropTypes.string,
       isFavorited: PropTypes.bool,

--- a/frontend/src/contexts/SingleItemContext.jsx
+++ b/frontend/src/contexts/SingleItemContext.jsx
@@ -75,7 +75,7 @@ export const SingleItemProvider = ({
         {
           ...defaultFolderTemplate,
           pk: tempPk,
-          displayName: duplicateNameHandler("New Folder", currentPathItems),
+          name: duplicateNameHandler("New Folder", currentPathItems),
           path: [...currentPath, tempPk],
           itemType: "folder",
           isDirectory: true,

--- a/frontend/src/exampleModals/CreateModal.jsx
+++ b/frontend/src/exampleModals/CreateModal.jsx
@@ -27,7 +27,7 @@ export function CreateModal({ onConfirm, onCancel }) {
           <button
             onClick={() =>
               onConfirm({
-                displayName: name,
+                name,
               })
             }
             style={{ marginLeft: 8 }}

--- a/frontend/src/exampleModals/ShareModal.jsx
+++ b/frontend/src/exampleModals/ShareModal.jsx
@@ -17,7 +17,7 @@ export function ShareModal({ onConfirm, onCancel, data }) {
       }}
     >
       <div style={{ background: "#fff", padding: 24, minWidth: 300 }}>
-        <h2>Share item - {data.map((item) => item.displayName).join(", ")}</h2>
+        <h2>Share item - {data.map((item) => item.name).join(", ")}</h2>
         <input
           style={{ width: "100%" }}
           value={email}
@@ -47,7 +47,7 @@ ShareModal.propTypes = {
   data: PropTypes.arrayOf(
     PropTypes.shape({
       pk: PropTypes.string.isRequired,
-      displayName: PropTypes.string.isRequired,
+      name: PropTypes.string.isRequired,
       itemType: PropTypes.oneOf(["folder", "resource"]).isRequired,
       iconName: PropTypes.string,
       isFavorited: PropTypes.bool,

--- a/frontend/src/index.d.ts
+++ b/frontend/src/index.d.ts
@@ -1,15 +1,15 @@
-import type { FC, ReactNode } from "react";
+import type { ReactElement, ReactNode } from "react";
 
-export interface ResourceManagerHeader {
+export interface ResourceManagerHeader<T extends object> {
   columnName: string;
-  getValue: (item: ResourceManagerItem) => any;
+  getValue: (item: ResourceManagerItem<T>) => any;
   sortAccessor?: (value: any) => any;
   isNameColumn?: boolean;
 }
 
-export interface ResourceManagerItem {
+export interface ResourceManagerItem<T extends object = object> {
   pk: string;
-  displayName: string;
+  name: string;
   itemType: "folder" | "resource";
   iconName: string;
   isFavorited: boolean;
@@ -17,49 +17,56 @@ export interface ResourceManagerItem {
   scopePk: string;
   createdAt: string;
   updatedAt: string;
-  resource: Record<string, any> | null;
-  resourcePk: string;
+  resource?: T;
+  resourcePk?: string;
   resourceType: "mmm" | "report" | "audience";
   parentPk?: string | null;
   path?: string[];
   isEditing?: boolean;
   isTemporary?: boolean;
+  isDirectory?: boolean;
 }
 
-export interface ResourceManagerPasteData {
-  copiedItems: ResourceManagerItem[];
+export interface ResourceManagerPasteData<T extends object = object> {
+  copiedItems: ResourceManagerItem<T>[];
   destinationFolder: ResourceManagerItem;
   operationType: "move" | "copy";
 }
 
-export interface ContextMenuItem {
+export interface ContextMenuItem<T extends object> {
   title: string;
   icon: string;
-  onClick?: (items: ResourceManagerItem) => void;
+  onClick?: (items: ResourceManagerItem<T>) => void;
   divider?: boolean;
-  hidden?: boolean | ((item: ResourceManagerItem) => boolean);
+  hidden?: boolean | ((item: ResourceManagerItem<T>) => boolean);
   className?: string;
-  children?: Omit<ContextMenuItem, "children">[];
+  children?: Omit<ContextMenuItem<T>, "children">[];
 }
 
-export interface ResourceManagerProps {
-  headers: ResourceManagerHeader[];
-  items: ResourceManagerItem[];
+export interface ResourceManagerProps<T extends object> {
+  headers: ResourceManagerHeader<T>[];
+  items: ResourceManagerItem<T>[];
   isLoading?: boolean;
-  onCreateFolder?: (data: ResourceManagerItem, lock: () => () => void) => void;
+  onCreateFolder?: (
+    data: ResourceManagerItem<T>,
+    lock: () => () => void
+  ) => void;
   onCreateItem?: (data: null, release: () => void) => void;
-  onRename?: (data: ResourceManagerItem, lock: () => () => void) => void;
-  onDelete?: (data: ResourceManagerItem[], lock: () => () => void) => void;
-  onDuplicate?: (data: ResourceManagerItem[], lock: () => () => void) => void;
-  onCut?: (data: ResourceManagerItem[], lock: () => () => void) => void;
-  onCopy?: (data: ResourceManagerItem[], lock: () => () => void) => void;
-  onPaste?: (data: ResourceManagerPasteData, lock: () => () => void) => void;
-  onShare?: (data: ResourceManagerItem[], release: () => void) => void;
-  onFavorite?: (data: ResourceManagerItem, lock: () => () => void) => void;
+  onRename?: (data: ResourceManagerItem<T>, lock: () => () => void) => void;
+  onDelete?: (data: ResourceManagerItem<T>[], lock: () => () => void) => void;
+  onDuplicate?: (
+    data: ResourceManagerItem<T>[],
+    lock: () => () => void
+  ) => void;
+  onCut?: (data: ResourceManagerItem<T>[], lock: () => () => void) => void;
+  onCopy?: (data: ResourceManagerItem<T>[], lock: () => () => void) => void;
+  onPaste?: (data: ResourceManagerPasteData<T>, lock: () => () => void) => void;
+  onShare?: (data: ResourceManagerItem<T>[], release: () => void) => void;
+  onFavorite?: (data: ResourceManagerItem<T>, lock: () => () => void) => void;
   onPathChange?: (path: string[]) => void;
   onRefresh?: (data: null, lock: () => () => void) => void;
-  onSelect?: (data: ResourceManagerItem[], lock: () => () => void) => void;
-  onOpen?: (data: ResourceManagerItem, lock: () => () => void) => void;
+  onSelect?: (data: ResourceManagerItem<T>[], lock: () => () => void) => void;
+  onOpen?: (data: ResourceManagerItem<T>, lock: () => () => void) => void;
   allowCreateFolder?: boolean;
   allowCreateItem?: boolean;
   allowRefresh?: boolean;
@@ -73,8 +80,8 @@ export interface ResourceManagerProps {
   allowDelete?: boolean;
   allowDuplicate?: boolean;
   initialPath?: string | null;
-  customEmptySelectCtxItems?: ContextMenuItem[];
-  customSelectCtxItems?: ContextMenuItem[];
+  customEmptySelectCtxItems?: ContextMenuItem<T>[];
+  customSelectCtxItems?: ContextMenuItem<T>[];
   renderCustomToolbar?: ReactNode;
   height?: string | number;
   width?: string | number;
@@ -82,4 +89,6 @@ export interface ResourceManagerProps {
   fontFamily?: string;
 }
 
-export declare const ResourceManager: FC<ResourceManagerProps>;
+export declare const ResourceManager: <T extends object>(
+  props: ResourceManagerProps<T>
+) => ReactElement;

--- a/frontend/src/utils/duplicateNameHandler.js
+++ b/frontend/src/utils/duplicateNameHandler.js
@@ -1,16 +1,13 @@
 export const duplicateNameHandler = (itemName, items) => {
-  if (items.find((i) => i.displayName === itemName)) {
+  if (items.find((i) => i.name === itemName)) {
     // Generating new item name for duplicate item
     let maxItemNum = 0;
     // If there exists a item with name itemName (1), itemName (2), etc.
     // Check if the number is greater than the maxItemNum, then set it to that greater number
     const itemNameRegex = new RegExp(`${itemName} \\(\\d+\\)`);
     items.forEach((i) => {
-      if (itemNameRegex.test(i.displayName)) {
-        const itemNumStr = i.displayName
-          .split(`${itemName} (`)
-          .pop()
-          .slice(0, -1);
+      if (itemNameRegex.test(i.name)) {
+        const itemNumStr = i.name.split(`${itemName} (`).pop().slice(0, -1);
         const itemNum = parseInt(itemNumStr);
         if (!isNaN(itemNum) && itemNum > maxItemNum) {
           maxItemNum = itemNum;


### PR DESCRIPTION
# 💄 Pull Request:  Generics types support & `displayName` -> `name` migration 

This PR modernizes and simplifies the type structure across the codebase by improving TypeScript generics handling and migrating component identification from `displayName` to the standard `name` property.

The goal is to make typing more consistent, readable, and easier to maintain while aligning component conventions

---

## ✅  Key Changes

### 🧩 Generics Refactor

- Refactored `index.d.ts` to use explicit generic constraints for improved type inference.

---

### 🏷️ `displayName` → `name` Migration

- Replaced `displayName` usage with the native `name` property
- Updated all internal references relying on `displayName`.