### PR TITLE
[FE-1333] :sparkles: Implement 'Open in new tab' feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,23 +174,24 @@ interface ResourceManagerHeader<T extends object> {
 
 All event handlers receive data and an optional `lock` function for UI control.
 
-| Handler          | Parameters         | Description                                     |
-| ---------------- | ------------------ | ----------------------------------------------- |
-| `onPageChange`   | `(page)`           | Called when the current page changes            |
-| `onCreateFolder` | `(data, lock)`     | Called when creating a new folder               |
-| `onCreateItem`   | `(data, release)`  | Called when creating custom items (modal event) |
-| `onOpen`         | `(data, lock)`     | Called when opening item                        |
-| `onDelete`       | `(items, lock)`    | Called when deleting items (modal event)        |
-| `onRename`       | `(item, lock)`     | Called when renaming an item                    |
-| `onCopy`         | `(items, lock)`    | Called when copying items                       |
-| `onCut`          | `(items, lock)`    | Called when cutting items                       |
-| `onPaste`        | `(data, lock)`     | Called when pasting items                       |
-| `onDuplicate`    | `(data, lock)`     | Called when duplicating items                   |
-| `onFavorite`     | `(item, lock)`     | Called when toggling favorites                  |
-| `onRefresh`      | `(data, lock)`     | Called when refreshing                          |
-| `onSelect`       | `(items, lock)`    | Called when selection changes                   |
-| `onShare`        | `(items, release)` | Called when sharing items (modal event)         |
-| `onPathChange`   | `(path)`           | Called on path change                           |
+| Handler          | Parameters         | Description                                            |
+| ---------------- | ------------------ | ------------------------------------------------------ |
+| `onPageChange`   | `(page)`           | Called when the current page changes                   |
+| `onCreateFolder` | `(data, lock)`     | Called when creating a new folder                      |
+| `onCreateItem`   | `(data, release)`  | Called when creating custom items (modal event)        |
+| `onOpen`         | `(data, lock)`     | Called when opening item (double-click or Enter)       |
+| `onOpenInNewTab` | `(data, lock)`     | Called when opening item in new tab (middle-click)     |
+| `onDelete`       | `(items, lock)`    | Called when deleting items (modal event)               |
+| `onRename`       | `(item, lock)`     | Called when renaming an item                           |
+| `onCopy`         | `(items, lock)`    | Called when copying items                              |
+| `onCut`          | `(items, lock)`    | Called when cutting items                              |
+| `onPaste`        | `(data, lock)`     | Called when pasting items                              |
+| `onDuplicate`    | `(data, lock)`     | Called when duplicating items                          |
+| `onFavorite`     | `(item, lock)`     | Called when toggling favorites                         |
+| `onRefresh`      | `(data, lock)`     | Called when refreshing                                 |
+| `onSelect`       | `(items, lock)`    | Called when selection changes                          |
+| `onShare`        | `(items, release)` | Called when sharing items (modal event)                |
+| `onPathChange`   | `(path)`           | Called on path change                                  |
 
 ### Lock/Release Pattern
 
@@ -249,23 +250,25 @@ const onCreateItem = (data, release) => {
 
 ## ⌨️ Keyboard Shortcuts
 
-| Action             | Shortcut        |
-| ------------------ | --------------- |
-| New Folder         | `Alt + N`       |
-| Cut                | `Ctrl + X`      |
-| Copy               | `Ctrl + C`      |
-| Paste              | `Ctrl + V`      |
-| Duplicate          | `Ctrl + D`      |
-| Rename             | `F2`            |
-| Delete             | `Del`           |
-| Select All         | `Ctrl + A`      |
-| Multi-select       | `Ctrl + Click`  |
-| Range Select       | `Shift + Click` |
-| Range Expand       | `Shift + ↑/↓`   |
-| Navigate Up/Down   | `↑/↓` arrows    |
-| Jump to First/Last | `Home/End`      |
-| Refresh            | `F5`            |
-| Clear Selection    | `Esc`           |
+| Action             | Shortcut           |
+| ------------------ | ------------------ |
+| New Folder         | `Alt + N`          |
+| Cut                | `Ctrl + X`         |
+| Copy               | `Ctrl + C`         |
+| Paste              | `Ctrl + V`         |
+| Duplicate          | `Ctrl + D`         |
+| Rename             | `F2`               |
+| Delete             | `Del`              |
+| Open               | `Enter`            |
+| Open in New Tab    | `Middle Click`     |
+| Select All         | `Ctrl + A`         |
+| Multi-select       | `Ctrl + Click`     |
+| Range Select       | `Shift + Click`    |
+| Range Expand       | `Shift + ↑/↓`      |
+| Navigate Up/Down   | `↑/↓` arrows       |
+| Jump to First/Last | `Home/End`         |
+| Refresh            | `F5`               |
+| Clear Selection    | `Esc`              |
 
 ## 🎨 Props
 
@@ -279,12 +282,12 @@ const onCreateItem = (data, release) => {
 | `onPageChange`              | `(page: number) => void`     | Called when the page changes                                                                      |
 | `allowCreateFolder`         | `boolean`                    | Enable folder creation (default: `true`)                                                          |
 | `allowCreateItem`           | `boolean`                    | Enable custom item creation (default: `true`)                                                     |
+| `allowOpenInNewTab`         | `boolean`                    | Enable open in new tab via middle-click and context menu (default: `true`)                        |
 | `allowRefresh`              | `boolean`                    | Enable refresh (default: `true`)                                                                  |
 | `allowShareItem`            | `boolean`                    | Enable sharing (default: `true`)                                                                  |
 | `allowCut`                  | `boolean`                    | Enable cutting (default: `true`)                                                                  |
 | `allowCopy`                 | `boolean`                    | Enable copying (default: `true`)                                                                  |
 | `allowFavorite`             | `boolean`                    | Enable favorites (default: `true`)                                                                |
-| `allowOpen`                 | `boolean`                    | Enable open action (default: `true`)                                                              |
 | `allowPaste`                | `boolean`                    | Enable pasting (default: `true`)                                                                  |
 | `allowRename`               | `boolean`                    | Enable renaming (default: `true`)                                                                 |
 | `allowDelete`               | `boolean`                    | Enable deletion (default: `true`)                                                                 |

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -174,23 +174,24 @@ interface ResourceManagerHeader<T extends object> {
 
 All event handlers receive data and an optional `lock` function for UI control.
 
-| Handler          | Parameters         | Description                                     |
-| ---------------- | ------------------ | ----------------------------------------------- |
-| `onPageChange`   | `(page)`           | Called when the current page changes            |
-| `onCreateFolder` | `(data, lock)`     | Called when creating a new folder               |
-| `onCreateItem`   | `(data, release)`  | Called when creating custom items (modal event) |
-| `onOpen`         | `(data, lock)`     | Called when opening item                        |
-| `onDelete`       | `(items, lock)`    | Called when deleting items (modal event)        |
-| `onRename`       | `(item, lock)`     | Called when renaming an item                    |
-| `onCopy`         | `(items, lock)`    | Called when copying items                       |
-| `onCut`          | `(items, lock)`    | Called when cutting items                       |
-| `onPaste`        | `(data, lock)`     | Called when pasting items                       |
-| `onDuplicate`    | `(data, lock)`     | Called when duplicating items                   |
-| `onFavorite`     | `(item, lock)`     | Called when toggling favorites                  |
-| `onRefresh`      | `(data, lock)`     | Called when refreshing                          |
-| `onSelect`       | `(items, lock)`    | Called when selection changes                   |
-| `onShare`        | `(items, release)` | Called when sharing items (modal event)         |
-| `onPathChange`   | `(path)`           | Called on path change                           |
+| Handler          | Parameters         | Description                                        |
+| ---------------- | ------------------ | -------------------------------------------------- |
+| `onPageChange`   | `(page)`           | Called when the current page changes               |
+| `onCreateFolder` | `(data, lock)`     | Called when creating a new folder                  |
+| `onCreateItem`   | `(data, release)`  | Called when creating custom items (modal event)    |
+| `onOpen`         | `(data, lock)`     | Called when opening item (double-click or Enter)   |
+| `onOpenInNewTab` | `(data, lock)`     | Called when opening item in new tab (middle-click) |
+| `onDelete`       | `(items, lock)`    | Called when deleting items (modal event)           |
+| `onRename`       | `(item, lock)`     | Called when renaming an item                       |
+| `onCopy`         | `(items, lock)`    | Called when copying items                          |
+| `onCut`          | `(items, lock)`    | Called when cutting items                          |
+| `onPaste`        | `(data, lock)`     | Called when pasting items                          |
+| `onDuplicate`    | `(data, lock)`     | Called when duplicating items                      |
+| `onFavorite`     | `(item, lock)`     | Called when toggling favorites                     |
+| `onRefresh`      | `(data, lock)`     | Called when refreshing                             |
+| `onSelect`       | `(items, lock)`    | Called when selection changes                      |
+| `onShare`        | `(items, release)` | Called when sharing items (modal event)            |
+| `onPathChange`   | `(path)`           | Called on path change                              |
 
 ### Lock/Release Pattern
 
@@ -258,6 +259,8 @@ const onCreateItem = (data, release) => {
 | Duplicate          | `Ctrl + D`      |
 | Rename             | `F2`            |
 | Delete             | `Del`           |
+| Open               | `Enter`         |
+| Open in New Tab    | `Middle Click`  |
 | Select All         | `Ctrl + A`      |
 | Multi-select       | `Ctrl + Click`  |
 | Range Select       | `Shift + Click` |
@@ -279,12 +282,12 @@ const onCreateItem = (data, release) => {
 | `onPageChange`              | `(page: number) => void`     | Called when the page changes                                                                      |
 | `allowCreateFolder`         | `boolean`                    | Enable folder creation (default: `true`)                                                          |
 | `allowCreateItem`           | `boolean`                    | Enable custom item creation (default: `true`)                                                     |
+| `allowOpenInNewTab`         | `boolean`                    | Enable open in new tab via middle-click and context menu (default: `true`)                        |
 | `allowRefresh`              | `boolean`                    | Enable refresh (default: `true`)                                                                  |
 | `allowShareItem`            | `boolean`                    | Enable sharing (default: `true`)                                                                  |
 | `allowCut`                  | `boolean`                    | Enable cutting (default: `true`)                                                                  |
 | `allowCopy`                 | `boolean`                    | Enable copying (default: `true`)                                                                  |
 | `allowFavorite`             | `boolean`                    | Enable favorites (default: `true`)                                                                |
-| `allowOpen`                 | `boolean`                    | Enable open action (default: `true`)                                                              |
 | `allowPaste`                | `boolean`                    | Enable pasting (default: `true`)                                                                  |
 | `allowRename`               | `boolean`                    | Enable renaming (default: `true`)                                                                 |
 | `allowDelete`               | `boolean`                    | Enable deletion (default: `true`)                                                                 |

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "@arimadata/resource-manager",
   "description": "A React resource manager with event-driven architecture and keyboard shortcuts. Designed to resemble Dropbox, it provides a complete interface for managing files and folders with built-in hooks for database persistence.",
   "private": false,
-  "version": "0.1.8",
+  "version": "0.1.9",
   "type": "module",
   "main": "dist/resource-manager.cjs.js",
   "module": "dist/resource-manager.es.js",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -158,6 +158,10 @@ function App() {
     console.log("onOpen -> data:", data);
   };
 
+  const onOpenInNewTab = (data, lock) => {
+    console.log("onOpenInNewTab -> data:", data);
+  };
+
   const onShare = (data, release) => {
     console.log("onShare -> data:", data);
     // 1. Setup modal handlers as needed with API calls if necessary
@@ -464,6 +468,7 @@ function App() {
           onCreateItem={onCreateItem}
           onCut={onCut}
           onOpen={onOpen}
+          onOpenInNewTab={onOpenInNewTab}
           onDelete={onDelete}
           onDuplicate={onDuplicate}
           renderCustomToolbar={customToolbar}

--- a/frontend/src/ResourceManager/Events/EventSubscribers.jsx
+++ b/frontend/src/ResourceManager/Events/EventSubscribers.jsx
@@ -20,6 +20,7 @@ export const EventSubscribers = ({
   onDuplicate,
   onFavorite,
   onOpen,
+  onOpenInNewTab,
   onPaste,
   onRefresh,
   onRename,
@@ -65,6 +66,7 @@ export const EventSubscribers = ({
     onDuplicate,
     onFavorite,
     onOpen,
+    onOpenInNewTab,
     onPaste,
     onRefresh,
     onRename,
@@ -108,6 +110,7 @@ export const EventSubscribers = ({
     duplicateItems: duplicateItems,
     toggleFavorite: () => toggleFavorite(eventBroker?.data),
     openItem: () => openItem(eventBroker?.data || selectedItems[0]),
+    openItemInNewTab: () => openItem(eventBroker?.data || selectedItems[0]),
     // Resetting events
     refresh: () => {
       // User pressed "refresh" button or "F5", this may be a
@@ -209,6 +212,7 @@ EventSubscribers.propTypes = {
   onDuplicate: PropTypes.func.isRequired,
   onFavorite: PropTypes.func.isRequired,
   onOpen: PropTypes.func.isRequired,
+  onOpenInNewTab: PropTypes.func.isRequired,
   onPaste: PropTypes.func.isRequired,
   onRefresh: PropTypes.func.isRequired,
   onRename: PropTypes.func.isRequired,

--- a/frontend/src/ResourceManager/ItemList/Item.jsx
+++ b/frontend/src/ResourceManager/ItemList/Item.jsx
@@ -50,6 +50,10 @@ const Item = ({
     eventBroker.publish("openItem", item);
   };
 
+  const handleItemAccessInNewTab = (item) => {
+    eventBroker.publish("openItemInNewTab", item);
+  };
+
   const handleItemShare = () => {
     if (!item.isDirectory) {
       eventBroker.publish("shareItems", [item]);
@@ -114,6 +118,15 @@ const Item = ({
     }
     setRightClickedItem(item);
     handleContextMenu(e, true);
+  };
+
+  const handleMiddleClick = (e) => {
+    if (e.button === 1) {
+      e.preventDefault();
+      e.stopPropagation();
+      if (!canSelectItems || item.isEditing) return;
+      handleItemAccessInNewTab(item);
+    }
   };
 
   const calculateHoverPosition = useCallback(
@@ -257,6 +270,7 @@ const Item = ({
             } ${isItemMoving ? "item-moving" : ""}`}
             title={isNameColumn ? item.name : undefined}
             onClick={handleItemSelection}
+            onAuxClick={handleMiddleClick}
             onContextMenu={handleItemContextMenu}
             onMouseEnter={handleMouseOver}
             onMouseLeave={handleMouseLeave}

--- a/frontend/src/ResourceManager/ResourceManager.jsx
+++ b/frontend/src/ResourceManager/ResourceManager.jsx
@@ -52,6 +52,7 @@ const ResourceManager = ({
   onDuplicate,
   onFavorite,
   onOpen,
+  onOpenInNewTab,
   onPaste,
   onRefresh,
   onRename,
@@ -60,6 +61,7 @@ const ResourceManager = ({
   onPathChange,
   allowCreateFolder = true,
   allowCreateItem = true,
+  allowOpenInNewTab = true,
   allowShareItem = true,
   allowCut = true,
   // allowCopy = true,
@@ -100,6 +102,7 @@ const ResourceManager = ({
     allowRename,
     allowFavorite,
     allowDuplicate,
+    allowOpenInNewTab,
     createItemLabel,
   };
 
@@ -158,6 +161,7 @@ const ResourceManager = ({
                     onDuplicate={onDuplicate}
                     onFavorite={onFavorite}
                     onOpen={onOpen}
+                    onOpenInNewTab={onOpenInNewTab}
                     onPaste={onPaste}
                     onRefresh={onRefresh}
                     onRename={onRename}
@@ -219,7 +223,7 @@ ResourceManager.propTypes = {
   onDelete: PropTypes.func,
   onDuplicate: PropTypes.func,
   onOpen: PropTypes.func,
-  allowOpen: PropTypes.bool,
+  onOpenInNewTab: PropTypes.func,
   onCut: PropTypes.func,
   onCopy: PropTypes.func,
   onPaste: PropTypes.func,
@@ -231,6 +235,7 @@ ResourceManager.propTypes = {
   onPathChange: PropTypes.func,
   allowCreateFolder: PropTypes.bool,
   allowCreateItem: PropTypes.bool,
+  allowOpenInNewTab: PropTypes.bool,
   allowShareItem: PropTypes.bool,
   allowCut: PropTypes.bool,
   allowCopy: PropTypes.bool,

--- a/frontend/src/contexts/SingleItemContext.jsx
+++ b/frontend/src/contexts/SingleItemContext.jsx
@@ -8,7 +8,7 @@ import {
   BsFiles,
 } from "react-icons/bs";
 import { FaRegFile, FaRegPaste, FaArrowUpFromBracket } from "react-icons/fa6";
-import { FiRefreshCw } from "react-icons/fi";
+import { FiExternalLink, FiRefreshCw } from "react-icons/fi";
 import { MdOutlineDelete } from "react-icons/md";
 import { PiFolderOpen } from "react-icons/pi";
 import { useClipBoard } from "./ClipboardContext";
@@ -131,6 +131,11 @@ export const SingleItemProvider = ({
 
   const handleItemOpen = () => {
     eventBroker.publish("openItem");
+    setVisible(false);
+  };
+
+  const handleOpenInNewTab = () => {
+    eventBroker.publish("openItemInNewTab");
     setVisible(false);
   };
 
@@ -292,6 +297,12 @@ export const SingleItemProvider = ({
         <FaRegFile size={16} />
       ),
       onClick: handleItemOpen,
+      divider: !resourceManagerCfg.allowOpenInNewTab,
+    },
+    resourceManagerCfg.allowOpenInNewTab && {
+      title: "Open in new tab",
+      icon: <FiExternalLink size={18} />,
+      onClick: handleOpenInNewTab,
       divider: true,
     },
     resourceManagerCfg.allowCut && {
@@ -417,6 +428,7 @@ SingleItemProvider.propTypes = {
     allowDelete: PropTypes.bool,
     allowFavorite: PropTypes.bool,
     allowDuplicate: PropTypes.bool,
+    allowOpenInNewTab: PropTypes.bool,
   }).isRequired,
   customEmptySelectCtxItems: PropTypes.array,
   customSelectCtxItems: PropTypes.array,

--- a/frontend/src/hooks/useEventBroker.js
+++ b/frontend/src/hooks/useEventBroker.js
@@ -169,6 +169,7 @@ export const useEventBroker = (resourceManagerCfg) => {
     "pasteItemsDone",
     // Item interactions
     "openItem",
+    "openItemInNewTab",
     "toggleFavorite",
   ];
   const releaseEvents = ["cancel", "refresh", "release"];
@@ -193,6 +194,7 @@ export const useEventBroker = (resourceManagerCfg) => {
         renameItem: resourceManagerCfg.allowRename,
         renameItemDone: resourceManagerCfg.allowRename,
         toggleFavorite: resourceManagerCfg.allowFavorite,
+        openItemInNewTab: resourceManagerCfg.allowOpenInNewTab,
       };
 
       return eventEnabledMap[eventName] || true;

--- a/frontend/src/hooks/useUserEventHandler.jsx
+++ b/frontend/src/hooks/useUserEventHandler.jsx
@@ -10,6 +10,7 @@ export const useUserEventHandler = ({
   onDuplicate,
   onFavorite,
   onOpen,
+  onOpenInNewTab,
   onPaste,
   onRefresh,
   onRename,
@@ -32,6 +33,7 @@ export const useUserEventHandler = ({
     renameItemDone: [onRename, null],
     toggleFavorite: [onFavorite, null],
     openItem: [onOpen, selectedItems[0]],
+    openItemInNewTab: [onOpenInNewTab, selectedItems[0]],
     refresh: [onRefresh, null],
     selectItemsDone: [onSelect, selectedItems],
   };

--- a/frontend/src/index.d.ts
+++ b/frontend/src/index.d.ts
@@ -71,14 +71,18 @@ export interface ResourceManagerProps<T extends object> {
   onRefresh?: (data: null, lock: () => () => void) => void;
   onSelect?: (data: ResourceManagerItem<T>[], lock: () => () => void) => void;
   onOpen?: (data: ResourceManagerItem<T>, lock: () => () => void) => void;
+  onOpenInNewTab?: (
+    data: ResourceManagerItem<T>,
+    lock: () => () => void
+  ) => void;
   allowCreateFolder?: boolean;
   allowCreateItem?: boolean;
+  allowOpenInNewTab?: boolean;
   allowRefresh?: boolean;
   allowShareItem?: boolean;
   allowCut?: boolean;
   allowCopy?: boolean;
   allowFavorite?: boolean;
-  allowOpen?: boolean;
   allowPaste?: boolean;
   allowRename?: boolean;
   allowDelete?: boolean;

--- a/frontend/src/utils/shortcuts.js
+++ b/frontend/src/utils/shortcuts.js
@@ -7,6 +7,7 @@ export const shortcuts = {
   rename: ["F2"],
   delete: ["Delete"],
   open: ["Enter"],
+  openInNewTab: ["MouseMiddle"],
   selectAll: ["Control", "A"],
   selectArrowUp: ["Shift", "ArrowUp"],
   selectArrowDown: ["Shift", "ArrowDown"],


### PR DESCRIPTION
## :memo: Description 
### **We need to extend shortcuts list with "MouseMiddle" and selected context menu for "Open in new tab" feature.**

## :hammer_and_wrench: Solution:
- Implemented "Open in new tab" feature
- Added `openInNewTab: ["MouseMiddle"]` shortcut declaration in `shortcuts.js`
- Added `allowOpenInNewTab` prop (default: `true`) to control feature availability
- Context menu "Open in new tab" item is conditionally rendered based on `allowOpenInNewTab` config
- Middle-click (mouse wheel button) triggers `onOpenInNewTab` callback when `allowOpenInNewTab` is enabled
- Added `openItemInNewTab` event to the event broker's enabled map for conditional registration
- Updated PropTypes in `SingleItemContext.jsx` to include `allowOpenInNewTab`
- Updated TypeScript types in `index.d.ts`
- Updated documentation in both `README.md` and `frontend/README.md` with new handler, shortcut, and prop