### PR TITLE
[FE-1392] :recycle: Enhance "Select All" functionality to select only items on the current page

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "@arimadata/resource-manager",
   "description": "A React resource manager with event-driven architecture and keyboard shortcuts. Designed to resemble Dropbox, it provides a complete interface for managing files and folders with built-in hooks for database persistence.",
   "private": false,
-  "version": "0.1.10",
+  "version": "0.1.11",
   "type": "module",
   "main": "dist/resource-manager.cjs.js",
   "module": "dist/resource-manager.es.js",

--- a/frontend/src/ResourceManager/ItemList/ItemList.jsx
+++ b/frontend/src/ResourceManager/ItemList/ItemList.jsx
@@ -1,7 +1,8 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import Item from "./Item";
 import PropTypes from "prop-types";
 import { useNavigation } from "../../contexts/NavigationContext";
+import { usePagination } from "../../contexts/PaginationContext";
 import ContextMenu from "../../components/ContextMenu/ContextMenu";
 import { useDetectOutsideClick } from "../../hooks/useDetectOutsideClick";
 import { useSingleItem } from "../../contexts/SingleItemContext";
@@ -11,20 +12,12 @@ import Loader from "../../components/Loader/Loader";
 import Pagination from "../../components/Pagination/Pagination";
 import "./ItemList.scss";
 
-const ItemList = ({
-  eventBroker,
-  headers,
-  isLoading,
-  primaryColor,
-  page,
-  pageSize,
-  onPageChange,
-  allowPagination,
-}) => {
+const ItemList = ({ eventBroker, headers, isLoading, primaryColor }) => {
   const { currentPathItems } = useNavigation();
+  const { currentPage, pageSize, allowPagination, handlePageChange } =
+    usePagination();
   const { selectedItemIndexes } = useSelection();
   const itemsViewRef = useRef(null);
-  const [internalPage, setInternalPage] = useState(page ?? 1);
 
   const {
     emptySelectCtxItems,
@@ -38,19 +31,6 @@ const ItemList = ({
   } = useSingleItem();
 
   const contextMenuRef = useDetectOutsideClick(() => setVisible(false));
-
-  const currentPage = page ?? internalPage;
-
-  const handlePageChange = useCallback(
-    (newPage) => {
-      if (onPageChange) {
-        onPageChange(newPage);
-      } else {
-        setInternalPage(newPage);
-      }
-    },
-    [onPageChange]
-  );
 
   const gridTemplateColumns = headers.map(() => "1fr").join(" ");
 
@@ -180,10 +160,6 @@ ItemList.propTypes = {
   ).isRequired,
   isLoading: PropTypes.bool,
   primaryColor: PropTypes.string,
-  page: PropTypes.number,
-  pageSize: PropTypes.number,
-  onPageChange: PropTypes.func,
-  allowPagination: PropTypes.bool,
 };
 
 export default ItemList;

--- a/frontend/src/ResourceManager/ItemList/ItemsHeader.jsx
+++ b/frontend/src/ResourceManager/ItemList/ItemsHeader.jsx
@@ -3,21 +3,34 @@ import { FaArrowDown } from "react-icons/fa6";
 import PropTypes from "prop-types";
 import Checkbox from "../../components/Checkbox/Checkbox";
 import { useSelection } from "../../contexts/SelectionContext";
-import { useNavigation } from "../../contexts/NavigationContext";
+import { usePagination } from "../../contexts/PaginationContext";
 import { SORT_DIRECTIONS } from "../../constants/sortDirections";
 import { useSorting } from "../../contexts/SortingContext";
+import { useNavigation } from "../../contexts/NavigationContext";
 
 const ItemsHeader = ({ eventBroker, headers }) => {
   const { selectedItems } = useSelection();
+  const { currentPage, pageSize, allowPagination } = usePagination();
   const { currentPathItems } = useNavigation();
   const { sortColumn, sortDirection, handleSort } = useSorting();
 
+  const paginatedItems = useMemo(() => {
+    if (!currentPathItems || currentPathItems.length === 0) return [];
+    if (!allowPagination) return currentPathItems;
+
+    const startIndex = (currentPage - 1) * pageSize;
+    const endIndex = startIndex + pageSize;
+    const slicedItems = currentPathItems.slice(startIndex, endIndex);
+    return slicedItems;
+  }, [currentPathItems, currentPage, pageSize, allowPagination]);
+
   const allItemsSelected = useMemo(() => {
-    return (
-      currentPathItems.length > 0 &&
-      selectedItems.length === currentPathItems.length
+    if (paginatedItems.length === 0) return;
+    const isAllSelected = paginatedItems.every((item) =>
+      selectedItems.some((selected) => selected.pk === item.pk)
     );
-  }, [selectedItems, currentPathItems]);
+    return isAllSelected;
+  }, [selectedItems, paginatedItems]);
 
   const handleSelectAll = (e) => {
     if (e.target.checked) {
@@ -56,7 +69,7 @@ const ItemsHeader = ({ eventBroker, headers }) => {
               onClick={(e) => e.stopPropagation()}
               onChange={handleSelectAll}
               title="Select all"
-              disabled={currentPathItems.length === 0}
+              disabled={paginatedItems.length === 0}
             />
           )}
           <span className="header-text">{header.columnName}</span>

--- a/frontend/src/ResourceManager/ResourceManager.jsx
+++ b/frontend/src/ResourceManager/ResourceManager.jsx
@@ -5,6 +5,7 @@ import { EventSubscribers } from "./Events/EventSubscribers";
 import { ItemsProvider } from "../contexts/ItemsContext";
 import { NavigationProvider } from "../contexts/NavigationContext";
 import { SelectionProvider } from "../contexts/SelectionContext";
+import { PaginationProvider } from "../contexts/PaginationContext";
 import { ClipBoardProvider } from "../contexts/ClipboardContext";
 import { useEventBroker } from "../hooks/useEventBroker";
 import { SingleItemProvider } from "../contexts/SingleItemContext";
@@ -121,57 +122,60 @@ const ResourceManager = ({
             headers={headers}
             onPathChange={onPathChange}
           >
-            <SelectionProvider eventBroker={eventBroker}>
-              <ClipBoardProvider eventBroker={eventBroker}>
-                {/* Toolbar with "New Folder", "Upload", "Refresh" */}
-                {/* On item click: converts to "Cut", "Copy", "Rename", "Download", "Delete", "(n) items selected"*/}
-                <SingleItemProvider
-                  eventBroker={eventBroker}
-                  resourceManagerCfg={resourceManagerCfg}
-                  customEmptySelectCtxItems={customEmptySelectCtxItems}
-                  customSelectCtxItems={customSelectCtxItems}
-                >
-                  <Toolbar
-                    resourceManagerCfg={resourceManagerCfg}
+            <PaginationProvider
+              page={page}
+              pageSize={pageSize}
+              allowPagination={allowPagination}
+              onPageChange={onPageChange}
+            >
+              <SelectionProvider eventBroker={eventBroker}>
+                <ClipBoardProvider eventBroker={eventBroker}>
+                  {/* Toolbar with "New Folder", "Upload", "Refresh" */}
+                  {/* On item click: converts to "Cut", "Copy", "Rename", "Download", "Delete", "(n) items selected"*/}
+                  <SingleItemProvider
                     eventBroker={eventBroker}
-                    renderCustomToolbar={renderCustomToolbar}
-                  />
-                  <div className="folders-preview" style={{ width: "100%" }}>
-                    <BreadCrumb eventBroker={eventBroker} />
-                    {/* Main section with files and folders */}
-                    <ItemList
+                    resourceManagerCfg={resourceManagerCfg}
+                    customEmptySelectCtxItems={customEmptySelectCtxItems}
+                    customSelectCtxItems={customSelectCtxItems}
+                  >
+                    <Toolbar
+                      resourceManagerCfg={resourceManagerCfg}
                       eventBroker={eventBroker}
-                      headers={headers}
-                      isLoading={isLoading}
-                      primaryColor={primaryColor}
-                      page={page}
-                      pageSize={pageSize}
-                      onPageChange={onPageChange}
-                      allowPagination={allowPagination}
+                      renderCustomToolbar={renderCustomToolbar}
                     />
-                  </div>
-                  {/* Event subscriber section such as "Delete" modal */}
-                  <EventSubscribers
-                    resourceManagerCfg={resourceManagerCfg}
-                    onCopy={onCopy}
-                    onCreateFolder={onCreateFolder}
-                    onCreateItem={onCreateItem}
-                    onCut={onCut}
-                    onDelete={onDelete}
-                    onDuplicate={onDuplicate}
-                    onFavorite={onFavorite}
-                    onOpen={onOpen}
-                    onOpenInNewTab={onOpenInNewTab}
-                    onPaste={onPaste}
-                    onRefresh={onRefresh}
-                    onRename={onRename}
-                    onSelect={onSelect}
-                    onShare={onShare}
-                    eventBroker={eventBroker}
-                  />
-                </SingleItemProvider>
-              </ClipBoardProvider>
-            </SelectionProvider>
+                    <div className="folders-preview" style={{ width: "100%" }}>
+                      <BreadCrumb eventBroker={eventBroker} />
+                      {/* Main section with files and folders */}
+                      <ItemList
+                        eventBroker={eventBroker}
+                        headers={headers}
+                        isLoading={isLoading}
+                        primaryColor={primaryColor}
+                      />
+                    </div>
+                    {/* Event subscriber section such as "Delete" modal */}
+                    <EventSubscribers
+                      resourceManagerCfg={resourceManagerCfg}
+                      onCopy={onCopy}
+                      onCreateFolder={onCreateFolder}
+                      onCreateItem={onCreateItem}
+                      onCut={onCut}
+                      onDelete={onDelete}
+                      onDuplicate={onDuplicate}
+                      onFavorite={onFavorite}
+                      onOpen={onOpen}
+                      onOpenInNewTab={onOpenInNewTab}
+                      onPaste={onPaste}
+                      onRefresh={onRefresh}
+                      onRename={onRename}
+                      onSelect={onSelect}
+                      onShare={onShare}
+                      eventBroker={eventBroker}
+                    />
+                  </SingleItemProvider>
+                </ClipBoardProvider>
+              </SelectionProvider>
+            </PaginationProvider>
           </NavigationProvider>
         </ItemsProvider>
       </SortingProvider>

--- a/frontend/src/contexts/PaginationContext.jsx
+++ b/frontend/src/contexts/PaginationContext.jsx
@@ -1,0 +1,59 @@
+import {
+  createContext,
+  useContext,
+  useState,
+  useMemo,
+  useCallback,
+} from "react";
+import PropTypes from "prop-types";
+
+const PaginationContext = createContext();
+
+export const PaginationProvider = ({
+  page: controlledPage,
+  pageSize,
+  allowPagination,
+  onPageChange,
+  children,
+}) => {
+  const [internalPage, setInternalPage] = useState(controlledPage ?? 1);
+
+  const currentPage = controlledPage ?? internalPage;
+
+  const handlePageChange = useCallback(
+    (newPage) => {
+      if (onPageChange) {
+        onPageChange(newPage);
+      } else {
+        setInternalPage(newPage);
+      }
+    },
+    [onPageChange]
+  );
+
+  const value = useMemo(
+    () => ({
+      currentPage,
+      pageSize,
+      allowPagination,
+      handlePageChange,
+    }),
+    [currentPage, pageSize, allowPagination, handlePageChange]
+  );
+
+  return (
+    <PaginationContext.Provider value={value}>
+      {children}
+    </PaginationContext.Provider>
+  );
+};
+
+PaginationProvider.propTypes = {
+  page: PropTypes.number,
+  pageSize: PropTypes.number.isRequired,
+  allowPagination: PropTypes.bool.isRequired,
+  onPageChange: PropTypes.func,
+  children: PropTypes.node.isRequired,
+};
+
+export const usePagination = () => useContext(PaginationContext);

--- a/frontend/src/contexts/SelectionContext.jsx
+++ b/frontend/src/contexts/SelectionContext.jsx
@@ -1,5 +1,6 @@
-import { createContext, useContext, useEffect, useState } from "react";
+import { createContext, useContext, useEffect, useMemo, useState } from "react";
 import { useNavigation } from "./NavigationContext";
+import { usePagination } from "./PaginationContext";
 import { arraysEqual } from "../utils/arraysEqual";
 import PropTypes from "prop-types";
 
@@ -7,9 +8,20 @@ const SelectionContext = createContext();
 
 export const SelectionProvider = ({ eventBroker, children }) => {
   const { currentPathItems } = useNavigation();
+  const { currentPage, pageSize, allowPagination } = usePagination();
   const [selectedItems, _setSelectedItems] = useState([]);
   const [selectedItemIndexes, _setSelectedItemIndexes] = useState([]);
   const [hoveredItem, setHoveredItem] = useState(null);
+
+  const paginatedItems = useMemo(() => {
+    if (!currentPathItems || currentPathItems.length === 0) return [];
+    if (!allowPagination) return currentPathItems;
+
+    const startIndex = (currentPage - 1) * pageSize;
+    const endIndex = startIndex + pageSize;
+    const slicedItems = currentPathItems.slice(startIndex, endIndex);
+    return slicedItems;
+  }, [currentPathItems, currentPage, pageSize, allowPagination]);
 
   ////////////////////////////////////////////////////////////
   // Event handlers
@@ -44,7 +56,7 @@ export const SelectionProvider = ({ eventBroker, children }) => {
   };
 
   const selectAll = () => {
-    setSelectedItems(currentPathItems);
+    setSelectedItems(paginatedItems);
   };
 
   const unselectAll = () => {


### PR DESCRIPTION
## :memo: Description 
### **The "select all" checkbox in the resource manager selects all items across every page, not just the visible page. When a user clicks "select all" and then "delete", it deletes everything. The checkbox logic needs to scope selection to only the items rendered on the current page.**

## :hammer_and_wrench: Solution:
- Created `PaginationContext.jsx` to centralize pagination state management across components
- `PaginationContext` exposes `paginatedItems`, `currentPage`, `pageSize`, `allowPagination`, `totalPages`, and `handlePageChange`
- Updated `SelectionContext.jsx` to use `paginatedItems` from `PaginationContext` for `selectAll()` function
- Updated `ItemsHeader.jsx` to check if all items on the current page are selected for the column checkbox state