### PR TITLE
[FE-1470] :bug: Fix shortcuts validation

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "@arimadata/resource-manager",
   "description": "A React resource manager with event-driven architecture and keyboard shortcuts. Designed to resemble Dropbox, it provides a complete interface for managing files and folders with built-in hooks for database persistence.",
   "private": false,
-  "version": "0.1.11",
+  "version": "0.1.12",
   "type": "module",
   "main": "dist/resource-manager.cjs.js",
   "module": "dist/resource-manager.es.js",

--- a/frontend/src/hooks/useKeyboardEventPublisher.js
+++ b/frontend/src/hooks/useKeyboardEventPublisher.js
@@ -1,12 +1,20 @@
 import { useKeyPress } from "./useKeyPress";
 import { shortcuts } from "../utils/shortcuts";
 import { useNavigation } from "../contexts/NavigationContext";
+import { useClipBoard } from "../contexts/ClipboardContext";
+import { useSelection } from "../contexts/SelectionContext";
+import { useItems } from "../contexts/ItemsContext";
 
 export const useKeyboardEventPublisher = ({
   eventBroker,
   resourceManagerCfg,
 }) => {
   const { currentFolder } = useNavigation();
+  const { clipBoard } = useClipBoard();
+  const { selectedItems } = useSelection();
+  const { items } = useItems();
+
+  const areItemsSelected = selectedItems.length > 0;
 
   const triggerCreateFolder = () => {
     eventBroker.publish("createFolder");
@@ -83,19 +91,31 @@ export const useKeyboardEventPublisher = ({
     triggerCreateFolder,
     !resourceManagerCfg.allowCreateFolder
   );
-  useKeyPress(shortcuts.cut, triggerCutItems, !resourceManagerCfg.allowCut);
-  useKeyPress(shortcuts.copy, triggerCopyItems, !resourceManagerCfg.allowCopy);
+  useKeyPress(
+    shortcuts.cut,
+    triggerCutItems,
+    !resourceManagerCfg.allowCut || !areItemsSelected
+  );
+  useKeyPress(
+    shortcuts.copy,
+    triggerCopyItems,
+    !resourceManagerCfg.allowCopy || !areItemsSelected
+  );
   useKeyPress(
     shortcuts.paste,
     triggerPasteItems,
-    !resourceManagerCfg.allowPaste
+    !resourceManagerCfg.allowPaste || !clipBoard
   );
-  useKeyPress(shortcuts.rename, triggerRename, !resourceManagerCfg.allowRename);
+  useKeyPress(
+    shortcuts.rename,
+    triggerRename,
+    !resourceManagerCfg.allowRename || selectedItems.length !== 1
+  );
   useKeyPress(shortcuts.delete, triggerDelete, !resourceManagerCfg.allowDelete);
   useKeyPress(shortcuts.open, triggerOpen);
   useKeyPress(shortcuts.jumpToFirst, triggerSelectFirst);
   useKeyPress(shortcuts.jumpToLast, triggerSelectLast);
-  useKeyPress(shortcuts.selectAll, triggerSelectAll);
+  useKeyPress(shortcuts.selectAll, triggerSelectAll, items.length === 0);
   useKeyPress(shortcuts.cancel, triggerCancel);
   useKeyPress(
     shortcuts.refresh,
@@ -109,6 +129,6 @@ export const useKeyboardEventPublisher = ({
   useKeyPress(
     shortcuts.duplicate,
     triggerDuplicateItems,
-    !resourceManagerCfg.allowDuplicate
+    !resourceManagerCfg.allowDuplicate || !areItemsSelected
   );
 };


### PR DESCRIPTION
## :memo: Description
### **Keyboard shortcuts (Cut, Copy, Paste, Select All, Rename, Duplicate) fired unconditionally - intercepting browser defaults even when no items were selected or clipboard was empty. This blocked native input behaviors (e.g. pasting text into a search bar).**

## :hammer_and_wrench: Solution:
- **Disabled Cut (Ctrl+X), Copy (Ctrl+C), and Duplicate shortcuts when no items are selected - allowing browser-native cut/copy to work in input fields**
- **Disabled Paste (Ctrl+V) shortcut when the clipboard is empty (no items have been cut/copied) - preserving native paste for text inputs**
- **Disabled Select All (Ctrl+A) when no items are available in the current view - allowing native text selection in inputs**
- **Disabled Rename (F2) when selection is not exactly one item - preventing invalid rename triggers**