### PR TITLE
[FE-2203] ✨ Added the ability to change the label for the Open button

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ const onCreateItem = (data, release) => {
 | `width`                     | `string \| number`           | Component width (default: `"100%"`)                                                               |
 | `primaryColor`              | `string`                     | Primary theme color (default: `"#6155b4"`)                                                        |
 | `fontFamily`                | `string`                     | Font family (default: `"Rubik, sans-serif"`)                                                      |
+| `openButtonLabel`           | `string`                     | Custom label for the Open button in hover actions and context menu (default: `"Open"`)            |
 
 ## 🏗️ Architecture
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -302,6 +302,7 @@ const onCreateItem = (data, release) => {
 | `width`                     | `string \| number`           | Component width (default: `"100%"`)                                                               |
 | `primaryColor`              | `string`                     | Primary theme color (default: `"#6155b4"`)                                                        |
 | `fontFamily`                | `string`                     | Font family (default: `"Rubik, sans-serif"`)                                                      |
+| `openButtonLabel`           | `string`                     | Custom label for the Open button in hover actions and context menu (default: `"Open"`)            |
 
 ## 🏗️ Architecture
 

--- a/frontend/src/ResourceManager/ItemList/Item.jsx
+++ b/frontend/src/ResourceManager/ItemList/Item.jsx
@@ -24,6 +24,7 @@ const Item = ({
   setRightClickedItem,
   headers,
   primaryColor,
+  openButtonLabel = "Open",
 }) => {
   const [itemSelected, setItemSelected] = useState(false);
   const [isEntering, setIsEntering] = useState(() => item.isTemporary);
@@ -263,9 +264,8 @@ const Item = ({
 
   return (
     <div
-      className={`item-container ${dropZoneClass} ${
-        itemSelected || !!item.isEditing ? "item-selected" : ""
-      } ${isItemMoving ? "item-moving" : ""}`}
+      className={`item-container ${dropZoneClass} ${itemSelected || !!item.isEditing ? "item-selected" : ""
+        } ${isItemMoving ? "item-moving" : ""}`}
       onMouseEnter={handleMouseOver}
       onMouseLeave={handleMouseLeave}
       onContextMenu={handleItemContextMenu}
@@ -276,13 +276,10 @@ const Item = ({
         return (
           <div
             key={header.columnName.toLowerCase().replace(" ", "-")}
-            className={`${
-              isNameColumn ? "item-name-cell" : "item-standard-cell"
-            } ${dropZoneClass} ${
-              itemSelected || !!item.isEditing ? "item-selected" : ""
-            } ${isItemMoving ? "item-moving" : ""} ${
-              isEntering ? "item-entering" : ""
-            }`}
+            className={`${isNameColumn ? "item-name-cell" : "item-standard-cell"
+              } ${dropZoneClass} ${itemSelected || !!item.isEditing ? "item-selected" : ""
+              } ${isItemMoving ? "item-moving" : ""} ${isEntering ? "item-entering" : ""
+              }`}
             onAnimationEnd={
               isEntering && isNameColumn ? handleEnterAnimationEnd : undefined
             }
@@ -365,9 +362,8 @@ const Item = ({
       {/* Hover Actions Overlay */}
       {itemHovered && hoverPosition && (
         <div
-          className={`item-hover-actions fixed-position ${
-            itemSelected ? "selected-background" : "default-background"
-          }`}
+          className={`item-hover-actions fixed-position ${itemSelected ? "selected-background" : "default-background"
+            }`}
           style={{
             top: hoverPosition.top,
             left: hoverPosition.left,
@@ -380,13 +376,13 @@ const Item = ({
           <div className="actions-container">
             <button
               className="action-btn"
-              title="Open"
+              title={openButtonLabel}
               onClick={(e) => {
                 e.stopPropagation();
                 handleItemAccess(item);
               }}
             >
-              <span>Open</span>
+              <span>{openButtonLabel}</span>
             </button>
             {!item.isDirectory && (
               <button
@@ -473,6 +469,7 @@ Item.propTypes = {
     })
   ).isRequired,
   primaryColor: PropTypes.string,
+  openButtonLabel: PropTypes.string,
 };
 
 export default Item;

--- a/frontend/src/ResourceManager/ItemList/ItemList.jsx
+++ b/frontend/src/ResourceManager/ItemList/ItemList.jsx
@@ -13,7 +13,7 @@ import Pagination from "../../components/Pagination/Pagination";
 import { buildGridTemplateColumns } from "../../utils/buildGridTemplateColumns";
 import "./ItemList.scss";
 
-const ItemList = ({ eventBroker, headers, isLoading, primaryColor }) => {
+const ItemList = ({ eventBroker, headers, isLoading, primaryColor, openButtonLabel }) => {
   const { currentPathItems } = useNavigation();
   const { currentPage, pageSize, allowPagination, handlePageChange } =
     usePagination();
@@ -111,6 +111,7 @@ const ItemList = ({ eventBroker, headers, isLoading, primaryColor }) => {
                 setRightClickedItem={setRightClickedItem}
                 headers={headers}
                 primaryColor={primaryColor}
+                openButtonLabel={openButtonLabel}
               />
             );
           })}
@@ -162,6 +163,7 @@ ItemList.propTypes = {
   ).isRequired,
   isLoading: PropTypes.bool,
   primaryColor: PropTypes.string,
+  openButtonLabel: PropTypes.string,
 };
 
 export default ItemList;

--- a/frontend/src/ResourceManager/ResourceManager.jsx
+++ b/frontend/src/ResourceManager/ResourceManager.jsx
@@ -81,6 +81,7 @@ const ResourceManager = ({
   width = "100%",
   fontFamily = "Rubik, sans-serif",
   primaryColor = "#6155b4",
+  openButtonLabel = "Open",
 }) => {
   const customStyles = {
     height,
@@ -105,6 +106,7 @@ const ResourceManager = ({
     allowDuplicate,
     allowOpenInNewTab,
     createItemLabel,
+    openButtonLabel,
   };
 
   const eventBroker = useEventBroker(resourceManagerCfg);
@@ -151,6 +153,7 @@ const ResourceManager = ({
                         headers={headers}
                         isLoading={isLoading}
                         primaryColor={primaryColor}
+                        openButtonLabel={openButtonLabel}
                       />
                     </div>
                     {/* Event subscriber section such as "Delete" modal */}
@@ -295,6 +298,7 @@ ResourceManager.propTypes = {
   width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   primaryColor: PropTypes.string,
   fontFamily: PropTypes.string,
+  openButtonLabel: PropTypes.string,
 };
 
 export default ResourceManager;

--- a/frontend/src/contexts/SingleItemContext.jsx
+++ b/frontend/src/contexts/SingleItemContext.jsx
@@ -290,7 +290,7 @@ export const SingleItemProvider = ({
         onClick: handleShareItem,
       },
     {
-      title: "Open",
+      title: resourceManagerCfg.openButtonLabel,
       icon: rightClickedItem?.isDirectory ? (
         <PiFolderOpen size={20} />
       ) : (
@@ -429,6 +429,7 @@ SingleItemProvider.propTypes = {
     allowFavorite: PropTypes.bool,
     allowDuplicate: PropTypes.bool,
     allowOpenInNewTab: PropTypes.bool,
+    openButtonLabel: PropTypes.string,
   }).isRequired,
   customEmptySelectCtxItems: PropTypes.array,
   customSelectCtxItems: PropTypes.array,

--- a/frontend/src/index.d.ts
+++ b/frontend/src/index.d.ts
@@ -98,6 +98,7 @@ export interface ResourceManagerProps<T extends object> {
   width?: string | number;
   primaryColor?: string;
   fontFamily?: string;
+  openButtonLabel?: string;
 }
 
 export declare const ResourceManager: <T extends object>(


### PR DESCRIPTION
### 📝 Description
### Add optional openButtonLabel prop to customize the Open button text

Introduces an optional openButtonLabel string prop (default: "Open") that allows consumers to override the label of the primary action button. The label is applied consistently in both the item hover actions overlay and the context menu entry. No breaking changes — existing behavior is preserved when the prop is omitted.

**Changes:**
ResourceManager — accepts and passes openButtonLabel down via resourceManagerCfg
ItemList → Item — prop forwarded through the component chain
SingleItemContext — context menu "Open" entry uses resourceManagerCfg.openButtonLabel
index.d.ts — TypeScript types updated
README.md — prop documented in the configuration table