### PR TITLE
[FE-2421] Resource Manager Navigation Fix

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import ResourceManager from "./ResourceManager/ResourceManager";
 import { renameAPI } from "./api/renameAPI";
 import { deleteAPI } from "./api/deleteAPI";
@@ -6,7 +6,6 @@ import { copyItemAPI, moveItemAPI } from "./api/itemTransferAPI";
 import { getAllItemsAPI } from "./api/getAllItemsAPI";
 import { createItemAPI } from "./api/createItemAPI";
 import { favoriteAPI } from "./api/favoriteAPI";
-import { useFolderNavigation } from "./hooks/useFolderNavigation";
 import "./App.scss";
 import { CreateModal } from "./exampleModals/CreateModal";
 import { ShareModal } from "./exampleModals/ShareModal";
@@ -112,14 +111,9 @@ const initialItems = [
 ];
 
 function App() {
-  const [loadingCount, setLoadingCount] = useState(0);
+  const [loadingCount, setLoadingCount] = useState(1);
   const [items, setItems] = useState(initialItems);
-  const [itemsLoaded, setItemsLoaded] = useState(false);
   const [modal, setModal] = useState(closedModal);
-  const { initialPath, syncPathWithUrl } = useFolderNavigation(
-    items,
-    itemsLoaded
-  );
   const isMountRef = useRef(false);
 
   const incrementLoadingCount = () => {
@@ -196,21 +190,10 @@ function App() {
     };
   };
 
-  const onPathChange = useCallback(
-    (newPath) => {
-      console.log("Path changed to:", newPath);
-      syncPathWithUrl(newPath);
-    },
-    [syncPathWithUrl]
-  );
-
-  ////////////////////////////////////////////////////
-
   const getItems = async () => {
     try {
       const response = await getAllItemsAPI();
       setItems(response.data.data);
-      setItemsLoaded(true);
     } catch (error) {
       console.error("Error getting items:", error);
     }
@@ -221,7 +204,6 @@ function App() {
     isMountRef.current = true;
 
     const loadInitialData = async () => {
-      incrementLoadingCount();
       try {
         await getItems();
       } finally {
@@ -489,8 +471,6 @@ function App() {
           onRename={onRename}
           onSelect={onSelect}
           onShare={onShare}
-          onPathChange={onPathChange}
-          initialPath={initialPath}
           customEmptySelectCtxItems={customEmptySelectCtxItems}
           customSelectCtxItems={customSelectCtxItems}
           height="100%"

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -114,8 +114,12 @@ const initialItems = [
 function App() {
   const [loadingCount, setLoadingCount] = useState(0);
   const [items, setItems] = useState(initialItems);
+  const [itemsLoaded, setItemsLoaded] = useState(false);
   const [modal, setModal] = useState(closedModal);
-  const { initialPath, syncPathWithUrl } = useFolderNavigation();
+  const { initialPath, syncPathWithUrl } = useFolderNavigation(
+    items,
+    itemsLoaded
+  );
   const isMountRef = useRef(false);
 
   const incrementLoadingCount = () => {
@@ -206,6 +210,7 @@ function App() {
     try {
       const response = await getAllItemsAPI();
       setItems(response.data.data);
+      setItemsLoaded(true);
     } catch (error) {
       console.error("Error getting items:", error);
     }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import ResourceManager from "./ResourceManager/ResourceManager";
 import { renameAPI } from "./api/renameAPI";
 import { deleteAPI } from "./api/deleteAPI";
@@ -6,6 +6,7 @@ import { copyItemAPI, moveItemAPI } from "./api/itemTransferAPI";
 import { getAllItemsAPI } from "./api/getAllItemsAPI";
 import { createItemAPI } from "./api/createItemAPI";
 import { favoriteAPI } from "./api/favoriteAPI";
+import { useFolderNavigation } from "./hooks/useFolderNavigation";
 import "./App.scss";
 import { CreateModal } from "./exampleModals/CreateModal";
 import { ShareModal } from "./exampleModals/ShareModal";
@@ -114,6 +115,7 @@ function App() {
   const [loadingCount, setLoadingCount] = useState(0);
   const [items, setItems] = useState(initialItems);
   const [modal, setModal] = useState(closedModal);
+  const { initialPath, syncPathWithUrl } = useFolderNavigation();
   const isMountRef = useRef(false);
 
   const incrementLoadingCount = () => {
@@ -190,9 +192,13 @@ function App() {
     };
   };
 
-  const onPathChange = (newPath) => {
-    console.log("Path changed to:", newPath);
-  };
+  const onPathChange = useCallback(
+    (newPath) => {
+      console.log("Path changed to:", newPath);
+      syncPathWithUrl(newPath);
+    },
+    [syncPathWithUrl]
+  );
 
   ////////////////////////////////////////////////////
 
@@ -479,7 +485,7 @@ function App() {
           onSelect={onSelect}
           onShare={onShare}
           onPathChange={onPathChange}
-          initialPath={null}
+          initialPath={initialPath}
           customEmptySelectCtxItems={customEmptySelectCtxItems}
           customSelectCtxItems={customSelectCtxItems}
           height="100%"

--- a/frontend/src/ResourceManager/ResourceManager.jsx
+++ b/frontend/src/ResourceManager/ResourceManager.jsx
@@ -1,3 +1,4 @@
+import { useCallback } from "react";
 import Toolbar from "./Toolbar/Toolbar";
 import BreadCrumb from "./BreadCrumb/BreadCrumb";
 import ItemList from "./ItemList/ItemList";
@@ -12,6 +13,7 @@ import { SingleItemProvider } from "../contexts/SingleItemContext";
 import { SortingProvider } from "../contexts/SortingContext";
 import PropTypes from "prop-types";
 import { dateStringValidator } from "../validators/propValidators";
+import { useFolderNavigation } from "../hooks/useFolderNavigation";
 import "./ResourceManager.scss";
 
 /**
@@ -40,7 +42,7 @@ import "./ResourceManager.scss";
 const ResourceManager = ({
   headers,
   items,
-  isLoading,
+  isLoading = false,
   page,
   pageSize = 15,
   onPageChange,
@@ -74,7 +76,6 @@ const ResourceManager = ({
   allowDuplicate = false,
   createItemLabel = "New item",
   allowPagination = true,
-  initialPath = null,
   customEmptySelectCtxItems = [],
   customSelectCtxItems = [],
   height = "auto",
@@ -108,6 +109,19 @@ const ResourceManager = ({
   };
 
   const eventBroker = useEventBroker(resourceManagerCfg);
+  const {
+    initialPath: urlInitialPath,
+    syncPathWithUrl,
+  } = useFolderNavigation(items, !isLoading);
+  const handlePathChange = useCallback(
+    (path) => {
+        syncPathWithUrl(path);
+      onPathChange?.(path);
+    },
+    [onPathChange, syncPathWithUrl]
+  );
+  const navigationInitialPath = urlInitialPath
+    
 
   return (
     <main
@@ -118,9 +132,9 @@ const ResourceManager = ({
       <SortingProvider>
         <ItemsProvider itemsData={items}>
           <NavigationProvider
-            initialPath={initialPath || []}
+            initialPath={navigationInitialPath}
             headers={headers}
-            onPathChange={onPathChange}
+            onPathChange={handlePathChange}
           >
             <PaginationProvider
               page={page}

--- a/frontend/src/contexts/NavigationContext.jsx
+++ b/frontend/src/contexts/NavigationContext.jsx
@@ -15,7 +15,7 @@ export const NavigationProvider = ({
 }) => {
   const { sortColumn, sortDirection } = useSorting();
   const { items } = useItems();
-  const isMountRef = useRef(false);
+  const previousInitialPathRef = useRef(initialPath || []);
   const [currentPath, setCurrentPath] = useState(initialPath || []);
   const [currentFolder, setCurrentFolder] = useState(null);
   const [currentPathItems, setCurrentPathItems] = useState([]);
@@ -55,6 +55,8 @@ export const NavigationProvider = ({
           const currentFolderPk = currentPath[currentPath.length - 1];
           return items.find((item) => item.pk === currentFolderPk) ?? null;
         });
+
+        console.log('items: ',items)
       } else {
         setCurrentPathItems([]);
         setCurrentFolder(null);
@@ -63,11 +65,17 @@ export const NavigationProvider = ({
   }, [items, currentPath, sortColumn, sortDirection, headers]);
 
   useEffect(() => {
-    if (!isMountRef.current && Array.isArray(items) && items.length > 0) {
-      setCurrentPath(initialPath || []);
-      isMountRef.current = true;
+    const nextInitialPath = initialPath || [];
+
+    if (!arraysEqual(previousInitialPathRef.current, nextInitialPath)) {
+      previousInitialPathRef.current = nextInitialPath;
+      setCurrentPath((previousPath) =>
+        arraysEqual(previousPath, nextInitialPath)
+          ? previousPath
+          : nextInitialPath
+      );
     }
-  }, [initialPath, items]);
+  }, [initialPath]);
 
   useEffect(() => {
     if (onPathChange) {

--- a/frontend/src/contexts/NavigationContext.jsx
+++ b/frontend/src/contexts/NavigationContext.jsx
@@ -19,6 +19,14 @@ export const NavigationProvider = ({
   const [currentPath, setCurrentPath] = useState(initialPath || []);
   const [currentFolder, setCurrentFolder] = useState(null);
   const [currentPathItems, setCurrentPathItems] = useState([]);
+  const currentFolderPk = currentPath.at(-1);
+  const resolvedCurrentFolder = currentFolderPk
+    ? items.find(
+        (item) => item.pk === currentFolderPk && item.isDirectory
+      ) ?? null
+    : null;
+  const resolvedCurrentPath = resolvedCurrentFolder?.path ?? currentPath;
+  const isCurrentPathResolved = currentPath.length === 0 || (resolvedCurrentFolder && arraysEqual(currentPath, resolvedCurrentPath));
 
   ////////////////////////////////////////////////////////////
   // Event handlers
@@ -35,6 +43,11 @@ export const NavigationProvider = ({
   // Context handlers
 
   useEffect(() => {
+    if (!arraysEqual(currentPath, resolvedCurrentPath)) {
+      setCurrentPath(resolvedCurrentPath);
+      return;
+    }
+
     if (Array.isArray(items)) {
       if (items.length > 0) {
         const currPathItems = items.filter((item) =>
@@ -56,13 +69,19 @@ export const NavigationProvider = ({
           return items.find((item) => item.pk === currentFolderPk) ?? null;
         });
 
-        console.log('items: ',items)
       } else {
         setCurrentPathItems([]);
         setCurrentFolder(null);
       }
     }
-  }, [items, currentPath, sortColumn, sortDirection, headers]);
+  }, [
+    items,
+    currentPath,
+    resolvedCurrentPath,
+    sortColumn,
+    sortDirection,
+    headers,
+  ]);
 
   useEffect(() => {
     const nextInitialPath = initialPath || [];
@@ -78,10 +97,10 @@ export const NavigationProvider = ({
   }, [initialPath]);
 
   useEffect(() => {
-    if (onPathChange) {
+    if (onPathChange && isCurrentPathResolved) {
       onPathChange(currentPath);
     }
-  }, [currentPath, onPathChange]);
+  }, [currentPath, isCurrentPathResolved, onPathChange]);
 
   return (
     <NavigationContext.Provider

--- a/frontend/src/hooks/useFolderNavigation.js
+++ b/frontend/src/hooks/useFolderNavigation.js
@@ -15,7 +15,7 @@ export const useFolderNavigation = () => {
   const [initialPath, setInitialPath] = useState(getFolderPathFromLocation);
 
   const syncPathWithUrl = useCallback((newPath) => {
-    const folderPk = newPath[0] ?? null;
+    const folderPk = newPath.at(-1) ?? null;
 
     setInitialPath((previousPath) =>
       arraysEqual(previousPath, newPath) ? previousPath : newPath

--- a/frontend/src/hooks/useFolderNavigation.js
+++ b/frontend/src/hooks/useFolderNavigation.js
@@ -4,6 +4,8 @@ import { arraysEqual } from "../utils/arraysEqual";
 const NAVIGATION_PATH_STATE_KEY = "resourceManagerPath";
 
 const getFolderPathFromLocation = () => {
+  if (typeof window === "undefined") return [];
+
   const historyPath = window.history.state?.[NAVIGATION_PATH_STATE_KEY];
   if (Array.isArray(historyPath)) return historyPath;
 
@@ -12,9 +14,11 @@ const getFolderPathFromLocation = () => {
 };
 
 export const useFolderNavigation = (items, canValidateFolder = false) => {
-  const [initialPath, setInitialPath] = useState(getFolderPathFromLocation);
+  const [initialPath, setInitialPath] = useState(getFolderPathFromLocation());
 
   const syncPathWithUrl = useCallback((newPath, replace = false) => {
+    if (typeof window === "undefined") return;
+
     const folderPk = newPath.at(-1) ?? null;
 
     setInitialPath((previousPath) =>
@@ -48,7 +52,13 @@ export const useFolderNavigation = (items, canValidateFolder = false) => {
 
   useEffect(() => {
     const accessedFolderPk = initialPath.at(-1);
-    if (!canValidateFolder || !accessedFolderPk || !Array.isArray(items)) return;
+    if (
+      !canValidateFolder ||
+      !accessedFolderPk ||
+      !Array.isArray(items)
+    ) {
+      return;
+    }
 
     const folderExists = items.some(
       (item) =>
@@ -62,6 +72,10 @@ export const useFolderNavigation = (items, canValidateFolder = false) => {
   }, [canValidateFolder, initialPath, items, syncPathWithUrl]);
 
   useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    setInitialPath(getFolderPathFromLocation());
+
     const handlePopState = () => {
       setInitialPath(getFolderPathFromLocation());
     };

--- a/frontend/src/hooks/useFolderNavigation.js
+++ b/frontend/src/hooks/useFolderNavigation.js
@@ -1,0 +1,59 @@
+import { useCallback, useEffect, useState } from "react";
+import { arraysEqual } from "../utils/arraysEqual";
+
+const NAVIGATION_PATH_STATE_KEY = "resourceManagerPath";
+
+const getFolderPathFromLocation = () => {
+  const historyPath = window.history.state?.[NAVIGATION_PATH_STATE_KEY];
+  if (Array.isArray(historyPath)) return historyPath;
+
+  const folderPk = new URL(window.location.href).searchParams.get("folderPk");
+  return folderPk ? [folderPk] : [];
+};
+
+export const useFolderNavigation = () => {
+  const [initialPath, setInitialPath] = useState(getFolderPathFromLocation);
+
+  const syncPathWithUrl = useCallback((newPath) => {
+    const folderPk = newPath[0] ?? null;
+
+    setInitialPath((previousPath) =>
+      arraysEqual(previousPath, newPath) ? previousPath : newPath
+    );
+
+    const url = new URL(window.location.href);
+
+    if (folderPk) {
+      url.searchParams.set("folderPk", folderPk);
+    } else {
+      url.searchParams.delete("folderPk");
+    }
+
+    const currentState =
+      window.history.state && typeof window.history.state === "object"
+        ? window.history.state
+        : {};
+    const historyPath = currentState[NAVIGATION_PATH_STATE_KEY];
+    const nextState = {
+      ...currentState,
+      [NAVIGATION_PATH_STATE_KEY]: [...newPath],
+    };
+
+    if (!Array.isArray(historyPath)) {
+      window.history.replaceState(nextState, "", url);
+    } else if (!arraysEqual(historyPath, newPath)) {
+      window.history.pushState(nextState, "", url);
+    }
+  }, []);
+
+  useEffect(() => {
+    const handlePopState = () => {
+      setInitialPath(getFolderPathFromLocation());
+    };
+
+    window.addEventListener("popstate", handlePopState);
+    return () => window.removeEventListener("popstate", handlePopState);
+  }, []);
+
+  return { initialPath, syncPathWithUrl };
+};

--- a/frontend/src/hooks/useFolderNavigation.js
+++ b/frontend/src/hooks/useFolderNavigation.js
@@ -11,10 +11,10 @@ const getFolderPathFromLocation = () => {
   return folderPk ? [folderPk] : [];
 };
 
-export const useFolderNavigation = () => {
+export const useFolderNavigation = (items, canValidateFolder = false) => {
   const [initialPath, setInitialPath] = useState(getFolderPathFromLocation);
 
-  const syncPathWithUrl = useCallback((newPath) => {
+  const syncPathWithUrl = useCallback((newPath, replace = false) => {
     const folderPk = newPath.at(-1) ?? null;
 
     setInitialPath((previousPath) =>
@@ -39,12 +39,27 @@ export const useFolderNavigation = () => {
       [NAVIGATION_PATH_STATE_KEY]: [...newPath],
     };
 
-    if (!Array.isArray(historyPath)) {
+    if (replace || !Array.isArray(historyPath)) {
       window.history.replaceState(nextState, "", url);
     } else if (!arraysEqual(historyPath, newPath)) {
       window.history.pushState(nextState, "", url);
     }
   }, []);
+
+  useEffect(() => {
+    const accessedFolderPk = initialPath.at(-1);
+    if (!canValidateFolder || !accessedFolderPk || !Array.isArray(items)) return;
+
+    const folderExists = items.some(
+      (item) =>
+        item.pk === accessedFolderPk &&
+        (item.isDirectory || item.itemType === "folder")
+    );
+
+    if (!folderExists) {
+      syncPathWithUrl([], true);
+    }
+  }, [canValidateFolder, initialPath, items, syncPathWithUrl]);
 
   useEffect(() => {
     const handlePopState = () => {

--- a/frontend/src/index.d.ts
+++ b/frontend/src/index.d.ts
@@ -90,7 +90,7 @@ export interface ResourceManagerProps<T extends object> {
   allowDuplicate?: boolean;
   createItemLabel?: string;
   allowPagination?: boolean;
-  initialPath?: string | null;
+  initialPath?: string[] | null;
   customEmptySelectCtxItems?: ContextMenuItem<T>[];
   customSelectCtxItems?: ContextMenuItem<T>[];
   renderCustomToolbar?: ReactNode;
@@ -103,3 +103,11 @@ export interface ResourceManagerProps<T extends object> {
 export declare const ResourceManager: <T extends object>(
   props: ResourceManagerProps<T>
 ) => ReactElement;
+
+export declare const useFolderNavigation: <T extends object>(
+  items: ResourceManagerItem<T>[],
+  canValidateFolder?: boolean
+) => {
+  initialPath: string[];
+  syncPathWithUrl: (newPath: string[], replace?: boolean) => void;
+};

--- a/frontend/src/index.d.ts
+++ b/frontend/src/index.d.ts
@@ -103,11 +103,3 @@ export interface ResourceManagerProps<T extends object> {
 export declare const ResourceManager: <T extends object>(
   props: ResourceManagerProps<T>
 ) => ReactElement;
-
-export declare const useFolderNavigation: <T extends object>(
-  items: ResourceManagerItem<T>[],
-  canValidateFolder?: boolean
-) => {
-  initialPath: string[];
-  syncPathWithUrl: (newPath: string[], replace?: boolean) => void;
-};

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,1 +1,2 @@
 export { default as ResourceManager } from "./ResourceManager/ResourceManager";
+export { useFolderNavigation } from "./hooks/useFolderNavigation";

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,2 +1,1 @@
 export { default as ResourceManager } from "./ResourceManager/ResourceManager";
-export { useFolderNavigation } from "./hooks/useFolderNavigation";


### PR DESCRIPTION
On the web app for the resource manager component, the browser back button takes the user to the root directory instead of the previous folder.

The goal is for the users to return to the parent folder using normal browser navigation without losing context; when in a nested folder.